### PR TITLE
Add sliding drawer for reviewer details

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -393,6 +393,269 @@
             width: 16px;
             height: 16px;
         }
+
+        /* Drawer styles */
+        .drawer {
+            position: fixed;
+            inset: 0;
+            z-index: 200;
+            display: none;
+        }
+
+        .drawer.open {
+            display: block;
+        }
+
+        .drawer-overlay {
+            position: absolute;
+            inset: 0;
+            background: rgba(0, 0, 0, 0.5);
+        }
+
+        .drawer-panel {
+            position: absolute;
+            top: 0;
+            right: 0;
+            height: 100%;
+            width: 100%;
+            max-width: 500px;
+            background: var(--bg-card);
+            color: var(--text-primary);
+            box-shadow: var(--shadow-lg);
+            display: flex;
+            flex-direction: column;
+            overflow-y: auto;
+        }
+
+        .drawer-close {
+            align-self: flex-end;
+            background: none;
+            border: none;
+            color: var(--text-primary);
+            font-size: 1.5rem;
+            padding: 1rem;
+            cursor: pointer;
+        }
+
+        /* Reviewer detail styles */
+        .reviewer-detail {
+            margin: 0;
+            padding: 0 200px;
+            min-height: 100vh;
+        }
+
+        .reviewer-detail-header {
+            background: var(--bg-card);
+            border-bottom: 1px solid var(--border);
+            padding: 2rem;
+            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        }
+
+        .back-link {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            color: var(--accent);
+            text-decoration: none;
+            font-size: 0.875rem;
+            margin-bottom: 1.5rem;
+            padding: 0.5rem 0;
+            transition: color 0.2s ease;
+        }
+
+        .back-link:hover {
+            color: var(--accent-hover);
+        }
+
+        .reviewer-detail-title {
+            font-size: 2rem;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 1rem;
+            line-height: 1.2;
+        }
+
+        .reviewer-detail-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1.5rem;
+            margin-bottom: 1.5rem;
+            color: var(--text-secondary);
+            font-size: 0.875rem;
+        }
+
+        .meta-item {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .reviewer-detail-description {
+            font-size: 1.125rem;
+            color: var(--text-secondary);
+            line-height: 1.6;
+            margin-bottom: 1.5rem;
+        }
+
+        .reviewer-detail-tags {
+            display: flex;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+        }
+
+        .detail-tag {
+            background: var(--bg-secondary);
+            color: var(--text-secondary);
+            padding: 0.5rem 1rem;
+            border-radius: 6px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            border: 1px solid var(--border);
+        }
+
+        .detail-tag.language {
+            background: var(--accent);
+            color: white;
+            border-color: var(--accent);
+        }
+
+        .reviewer-content {
+            background: var(--bg-card);
+            border-bottom: 1px solid var(--border);
+            padding: 2rem;
+        }
+
+        .content-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 1.5rem;
+            padding-bottom: 1rem;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .content-title {
+            font-size: 1.25rem;
+            font-weight: 600;
+            color: var(--text-primary);
+        }
+
+        .button-group {
+            display: flex;
+            gap: 0.75rem;
+            align-items: center;
+        }
+
+        .copy-button, .deploy-button {
+            border: none;
+            padding: 0.5rem 1rem;
+            border-radius: 6px;
+            cursor: pointer;
+            font-size: 0.875rem;
+            font-weight: 500;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+            transition: background-color 0.2s ease;
+        }
+
+        .copy-button {
+            background: var(--accent);
+            color: white;
+        }
+
+        .copy-button:hover {
+            background: var(--accent-hover);
+        }
+
+        .deploy-button {
+            background: var(--bg-secondary);
+            color: var(--text-primary);
+            border: 1px solid var(--border);
+        }
+
+        .deploy-button:hover {
+            background: var(--border);
+        }
+
+        .reviewer-prompt {
+            background: var(--bg-secondary);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1.5rem;
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            font-size: 0.875rem;
+            line-height: 1.6;
+            color: var(--text-primary);
+            white-space: pre-wrap;
+            overflow-x: auto;
+            position: relative;
+        }
+
+        .stats-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 1rem;
+            padding: 2rem;
+            background: var(--bg-primary);
+        }
+
+        .stat-card {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1.5rem;
+            text-align: center;
+        }
+
+        .stat-value {
+            font-size: 2rem;
+            font-weight: 700;
+            color: var(--accent);
+            margin-bottom: 0.5rem;
+        }
+
+        .stat-label {
+            color: var(--text-secondary);
+            font-size: 0.875rem;
+        }
+
+        @media (max-width: 768px) {
+            .reviewer-detail {
+                padding: 0 5px;
+            }
+
+            .reviewer-detail-header {
+                padding: 1.5rem;
+            }
+
+            .reviewer-detail-title {
+                font-size: 1.5rem;
+            }
+
+            .reviewer-detail-meta {
+                flex-direction: column;
+                gap: 0.75rem;
+            }
+
+            .content-header {
+                flex-direction: column;
+                gap: 1rem;
+                align-items: stretch;
+            }
+
+            .button-group {
+                flex-direction: column;
+            }
+
+            .reviewer-content {
+                padding: 1.5rem;
+            }
+
+            .stats-grid {
+                padding: 1.5rem;
+            }
+        }
     </style>
 </head>
 <body>
@@ -517,7 +780,7 @@
     }
 
     // Add event listeners when DOM is loaded
-    document.addEventListener('DOMContentLoaded', function() {
+document.addEventListener('DOMContentLoaded', function() {
         const searchInput = document.getElementById('search');
         const categoryFilter = document.getElementById('category-filter');
         const repoFilter = document.getElementById('repo-filter');
@@ -528,6 +791,53 @@
         if (repoFilter) repoFilter.addEventListener('change', filterReviewers);
         if (languageFilter) languageFilter.addEventListener('change', filterReviewers);
     });
+
+    function openDrawer(url) {
+        const drawer = document.getElementById('drawer');
+        const content = document.getElementById('drawer-content');
+        fetch(url)
+            .then(r => r.text())
+            .then(html => {
+                const doc = new DOMParser().parseFromString(html, 'text/html');
+                const detail = doc.querySelector('.reviewer-detail');
+                if (detail) {
+                    const back = detail.querySelector('.back-link');
+                    if (back) back.remove();
+                    content.innerHTML = detail.innerHTML;
+                } else {
+                    content.innerHTML = html;
+                }
+                drawer.classList.add('open');
+            });
+    }
+
+    function closeDrawer() {
+        const drawer = document.getElementById('drawer');
+        const content = document.getElementById('drawer-content');
+        drawer.classList.remove('open');
+        content.innerHTML = '';
+    }
+
+    function copyPrompt() {
+        const promptContent = document.getElementById('prompt-content');
+        const copyButton = document.querySelector('.copy-button');
+        const copyText = document.getElementById('copy-text');
+
+        const textarea = document.createElement('textarea');
+        textarea.value = promptContent.textContent;
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+
+        copyButton.classList.add('copied');
+        copyText.textContent = 'Copied!';
+
+        setTimeout(() => {
+            copyButton.classList.remove('copied');
+            copyText.textContent = 'Copy Prompt';
+        }, 2000);
+    }
 </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@ layout: default
                  data-repo="{{ reviewer.repository }}"
                  data-category="{{ reviewer.label }}"
                  data-language="{{ reviewer.language }}"
-                 onclick="window.location.href='{{ reviewer.url }}'">
+                 onclick="openDrawer('{{ reviewer.url }}')">
                 <div class="reviewer-header">
                     <div>
                         <h3 class="reviewer-title">{{ reviewer.title }}</h3>
@@ -95,3 +95,11 @@ layout: default
         </div>
     </div>
 </main>
+
+<div id="drawer" class="drawer">
+    <div class="drawer-overlay" onclick="closeDrawer()"></div>
+    <div class="drawer-panel">
+        <button class="drawer-close" onclick="closeDrawer()">&times;</button>
+        <div id="drawer-content"></div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- add drawer overlay styles and review detail styles in default layout
- implement JS functions to open the drawer and load reviewer details
- replace card navigation with drawer in `index.html`
- append drawer markup after the reviewer grid

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685bc451282c832b9799e0f08e3e5d26