### PR TITLE
Update fonts to Inter

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,6 +6,9 @@
     <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
     <meta name="description" content="{{ page.description | default: site.description }}">
     <link rel="icon" type="image/x-icon" href="/favicon.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 
     <style>
         :root {
@@ -43,7 +46,7 @@
         }
 
         body {
-            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             background: var(--bg-primary);
             color: var(--text-primary);
             line-height: 1.6;

--- a/_layouts/reviewer.html
+++ b/_layouts/reviewer.html
@@ -148,7 +148,7 @@ layout: default
         border: 1px solid var(--border);
         border-radius: 8px;
         padding: 1.5rem;
-        font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+        font-family: 'Inter', sans-serif;
         font-size: 0.875rem;
         line-height: 1.6;
         color: var(--text-primary);


### PR DESCRIPTION
# User description
## Summary
- use Google Fonts Inter across the site
- update page styles to use Inter

## Testing
- `bundle install --gemfile=gemfile`
- `bundle exec jekyll -v --gemfile=gemfile` *(fails: can't find gem jekyll)*

------
https://chatgpt.com/codex/tasks/task_b_685bd3b86338832b93b68b09b0792358

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Implement site-wide typography update by integrating Google Fonts' Inter font family and applying it as the primary font across regular content and previously monospaced elements. Update font stack in layout templates to maintain system fonts as fallbacks while prioritizing Inter.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>nimrodkor</td><td>Nicer-UI</td><td>June 23, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Join @guyeisenkot and the rest of your team on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/3?tool=ast>(Baz)</a>.