### PR TITLE
Improve header links and layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
     <link rel="icon" type="image/x-icon" href="/favicon.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 
     <style>
         :root {
@@ -50,7 +50,12 @@
             background: var(--bg-primary);
             color: var(--text-primary);
             line-height: 1.6;
+            font-weight: 400;
             transition: background-color 0.3s ease, color 0.3s ease;
+        }
+
+        h1, h2, h3, h4, h5, h6 {
+            font-weight: 500;
         }
 
         .container {
@@ -110,6 +115,56 @@
             align-items: center;
             justify-content: flex-end;
             gap: 1rem;
+        }
+
+        .header-left {
+            display: flex;
+            align-items: center;
+            gap: 1rem;
+        }
+
+        .header-links {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+        }
+
+        .header-link {
+            text-decoration: none;
+            padding: 0.375rem 0.75rem;
+            border-radius: 6px;
+            font-size: 0.875rem;
+            font-weight: 500;
+            transition: background-color 0.2s ease;
+        }
+
+        .header-link.primary {
+            background: var(--accent);
+            color: white;
+        }
+
+        .header-link.primary:hover {
+            background: var(--accent-hover);
+        }
+
+        .header-link.secondary {
+            background: none;
+            border: 1px solid var(--border);
+            color: var(--text-primary);
+        }
+
+        .header-link.secondary:hover {
+            background: var(--bg-secondary);
+        }
+
+        .header-link.discovery {
+            background: var(--bg-secondary);
+            border: 1px solid var(--border);
+            color: var(--text-primary);
+        }
+
+        .header-link.discovery:hover {
+            background: var(--border);
         }
 
         .theme-switch-container {
@@ -190,7 +245,7 @@
 
         .hero h1 {
             font-size: 2.5rem;
-            font-weight: 800;
+            font-weight: 500;
             margin-bottom: 1rem;
             background: linear-gradient(135deg, var(--accent), #8b5cf6);
             -webkit-background-clip: text;
@@ -301,7 +356,7 @@
 
         .reviewer-title {
             font-size: 1.125rem;
-            font-weight: 600;
+            font-weight: 500;
             color: var(--text-primary);
             margin-bottom: 0.25rem;
         }
@@ -367,8 +422,18 @@
             border-top: 1px solid var(--border);
             padding: 2rem 0;
             margin-top: 4rem;
-            text-align: center;
+            text-align: left;
             color: var(--text-muted);
+        }
+
+        .footer a {
+            color: var(--accent);
+            text-decoration: none;
+            margin-left: 1rem;
+        }
+
+        .footer a:hover {
+            text-decoration: underline;
         }
 
         @media (max-width: 768px) {
@@ -472,7 +537,7 @@
 
         .reviewer-detail-title {
             font-size: 2rem;
-            font-weight: 700;
+            font-weight: 500;
             color: var(--text-primary);
             margin-bottom: 1rem;
             line-height: 1.2;
@@ -539,7 +604,7 @@
 
         .content-title {
             font-size: 1.25rem;
-            font-weight: 600;
+            font-weight: 500;
             color: var(--text-primary);
         }
 
@@ -665,23 +730,30 @@
 <header class="header">
     <div class="container">
         <div class="header-content">
-            <div class="theme-switch-container">
-                <div class="theme-switch">
-                    <button class="theme-option light" onclick="setTheme('light')">
-                        <svg width="16" height="16" viewBox="0 0 16 16" class="theme-icon">
-                            <path fill-rule="evenodd" d="M8 12a4 4 0 100-8 4 4 0 000 8zM8 0a.5.5 0 01.5.5v2a.5.5 0 01-1 0v-2A.5.5 0 018 0zm0 13a.5.5 0 01.5.5v2a.5.5 0 01-1 0v-2A.5.5 0 018 13zm8-5a.5.5 0 01-.5.5h-2a.5.5 0 010-1h2a.5.5 0 01.5.5zM3 8a.5.5 0 01-.5.5h-2a.5.5 0 010-1h2A.5.5 0 013 8zm10.657-5.657a.5.5 0 010 .707l-1.414 1.415a.5.5 0 11-.707-.708l1.414-1.414a.5.5 0 01.707 0zm-9.193 9.193a.5.5 0 010 .707L3.05 13.657a.5.5 0 01-.707-.707l1.414-1.414a.5.5 0 01.707 0zm9.193 0a.5.5 0 01-.707 0L11.536 13.95a.5.5 0 01.707.707l1.414-1.414a.5.5 0 010-.707zM4.464 4.465a.5.5 0 01-.707 0L2.343 3.05a.5.5 0 11.707-.707l1.414 1.414a.5.5 0 010 .708z"/>
-                        </svg>
-                        <span>Light</span>
-                    </button>
-                    <button class="theme-option dark" onclick="setTheme('dark')">
-                        <svg width="16" height="16" viewBox="0 0 16 16" class="theme-icon">
-                            <path d="M6 .278a.768.768 0 01.08.858 7.208 7.208 0 00-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.787.787 0 01.81.316.733.733 0 01-.031.893A8.349 8.349 0 018.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.752.752 0 016 .278z"/>
-                        </svg>
-                        <span>Dark</span>
-                    </button>
+            <div class="header-left">
+                <div class="header-links">
+                    <a href="https://baz.co/agents" class="header-link primary" target="_blank" rel="noopener noreferrer">Deploy agents</a>
+                    <a href="https://docs.baz.co/basics/model-context-protocol-mcp" class="header-link discovery" target="_blank" rel="noopener noreferrer">MCP</a>
+                    <a href="https://docs.baz.co" class="header-link secondary" target="_blank" rel="noopener noreferrer">Learn more</a>
+                </div>
+                <div class="theme-switch-container">
+                    <div class="theme-switch">
+                        <button class="theme-option light" onclick="setTheme('light')">
+                            <svg width="16" height="16" viewBox="0 0 16 16" class="theme-icon">
+                                <path fill-rule="evenodd" d="M8 12a4 4 0 100-8 4 4 0 000 8zM8 0a.5.5 0 01.5.5v2a.5.5 0 01-1 0v-2A.5.5 0 018 0zm0 13a.5.5 0 01.5.5v2a.5.5 0 01-1 0v-2A.5.5 0 018 13zm8-5a.5.5 0 01-.5.5h-2a.5.5 0 010-1h2a.5.5 0 01.5.5zM3 8a.5.5 0 01-.5.5h-2a.5.5 0 010-1h2A.5.5 0 013 8zm10.657-5.657a.5.5 0 010 .707l-1.414 1.415a.5.5 0 11-.707-.708l1.414-1.414a.5.5 0 01.707 0zm-9.193 9.193a.5.5 0 010 .707L3.05 13.657a.5.5 0 01-.707-.707l1.414-1.414a.5.5 0 01.707 0zm9.193 0a.5.5 0 01-.707 0L11.536 13.95a.5.5 0 01.707.707l1.414-1.414a.5.5 0 010-.707zM4.464 4.465a.5.5 0 01-.707 0L2.343 3.05a.5.5 0 11.707-.707l1.414 1.414a.5.5 0 010 .708z"/>
+                            </svg>
+                            <span>Light</span>
+                        </button>
+                        <button class="theme-option dark" onclick="setTheme('dark')">
+                            <svg width="16" height="16" viewBox="0 0 16 16" class="theme-icon">
+                                <path d="M6 .278a.768.768 0 01.08.858 7.208 7.208 0 00-.878 3.46c0 4.021 3.278 7.277 7.318 7.277.527 0 1.04-.055 1.533-.16a.787.787 0 01.81.316.733.733 0 01-.031.893A8.349 8.349 0 018.344 16C3.734 16 0 12.286 0 7.71 0 4.266 2.114 1.312 5.124.06A.752.752 0 016 .278z"/>
+                            </svg>
+                            <span>Dark</span>
+                        </button>
+                    </div>
                 </div>
             </div>
-                <a href="https://baz.co" class="logo" target="_blank" rel="noopener noreferrer">
+            <a href="https://baz.co" class="logo" target="_blank" rel="noopener noreferrer">
                 <div class="logo-icon">
                     <img src="/assets/baz-light.svg" alt="Logo" class="logo-light" width="80" height="80">
                     <img src="/assets/baz-dark.svg" alt="Logo" class="logo-dark" width="80" height="80" style="display: none;">
@@ -696,6 +768,7 @@
 <footer class="footer">
     <div class="container">
         <p>&copy; 2025 Baz Technologies. Ready-to-use system prompts for better code reviews.</p>
+        <a href="https://x.com/baz_scm" target="_blank" rel="noopener noreferrer">Follow us on X</a>
     </div>
 </footer>
 

--- a/_layouts/reviewer.html
+++ b/_layouts/reviewer.html
@@ -9,6 +9,10 @@ layout: default
         min-height: 100vh;
     }
 
+    h1, h2, h3, h4, h5, h6 {
+        font-weight: 500;
+    }
+
     .reviewer-detail-header {
         background: var(--bg-card);
         border-bottom: 1px solid var(--border);
@@ -34,7 +38,7 @@ layout: default
 
     .reviewer-detail-title {
         font-size: 2rem;
-        font-weight: 700;
+        font-weight: 500;
         color: var(--text-primary);
         margin-bottom: 1rem;
         line-height: 1.2;
@@ -101,7 +105,7 @@ layout: default
 
     .content-title {
         font-size: 1.25rem;
-        font-weight: 600;
+        font-weight: 500;
         color: var(--text-primary);
     }
 

--- a/index.html
+++ b/index.html
@@ -16,7 +16,6 @@ layout: default
                 <input type="text" id="search" class="search-input" placeholder="Search reviewers...">
             </div>
             <div class="filter-group">
-                <label for="category-filter">Category</label>
                 <select id="category-filter" class="filter-select">
                     <option value="">All Categories</option>
                     {% assign categories = site.reviewers | map: 'label' | uniq | sort %}
@@ -26,7 +25,6 @@ layout: default
                 </select>
             </div>
             <div class="filter-group">
-                <label for="repo-filter">Repository</label>
                 <select id="repo-filter" class="filter-select">
                     <option value="">All Repositories</option>
                     {% assign repositories = site.reviewers | map: 'repository' | uniq | sort %}
@@ -36,7 +34,6 @@ layout: default
                 </select>
             </div>
             <div class="filter-group">
-                <label for="language-filter">Language</label>
                 <select id="language-filter" class="filter-select">
                     <option value="">All Languages</option>
                     {% assign languages = site.reviewers | map: 'language' | uniq | sort %}


### PR DESCRIPTION
## Summary
- add deployment, MCP, and docs links in header
- remove filter labels and tweak footer layout
- lighten header font weights and update global fonts
- add link to Baz on X

## Testing
- `bundle install --gemfile=gemfile` *(fails: Could not complete bundle install)*

------
https://chatgpt.com/codex/tasks/task_b_685be7944070832b989b1ad834d82539