### PR TITLE
Fix dark mode styles

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -221,7 +221,7 @@
         [data-theme="dark"] .theme-option.dark {
             background: #DEE5EF;
             border: 1px solid transparent;
-            color: #ffffff;
+            color: #000000;
         }
 
         :root:not([data-theme="dark"]) .theme-option.light {
@@ -328,7 +328,7 @@
             padding: 0.5rem;
             border-radius: 6px;
             cursor: pointer;
-            font-size: 0.875rem;
+            font-size: 16px;
             transition: all 0.2s ease;
             display: flex;
             align-items: center;
@@ -449,6 +449,10 @@
         .tag.language {
             background: #DEE5EF;
             color: var(--text-primary);
+        }
+
+        [data-theme="dark"] .tag.language {
+            color: #000000;
         }
 
         .footer {
@@ -632,6 +636,10 @@
             background: #DEE5EF;
             color: var(--text-primary);
             border-color: transparent;
+        }
+
+        [data-theme="dark"] .detail-tag.language {
+            color: #000000;
         }
 
         .reviewer-content {

--- a/_layouts/reviewer.html
+++ b/_layouts/reviewer.html
@@ -89,6 +89,10 @@ layout: default
         border-color: transparent;
     }
 
+    [data-theme="dark"] .detail-tag.language {
+        color: #000000;
+    }
+
     .reviewer-content {
         background: var(--bg-card);
         border-bottom: 1px solid var(--border);


### PR DESCRIPTION
# User description
## Summary
- fix dark mode color for the dark theme option button
- show black text for language tags in dark mode
- enlarge the clear filters symbol to 16px

## Testing
- `BUNDLE_GEMFILE=gemfile bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_685c406b7570832ba3b154e17df8420c

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Improve dark mode styling by fixing text colors and sizes across theme option buttons and language tags. Enhance readability by setting appropriate text colors in dark mode and standardizing button sizes to 16px.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>UI-refinements-for-lib...</td><td>June 25, 2025</td></tr>
<tr><td>nimrodkor</td><td>Nicer-UI</td><td>June 23, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Join @guyeisenkot and the rest of your team on <a href=https://main.baz.ninja/changes/baz-scm/awesome-reviewers/6?tool=ast>(Baz)</a>.