### PR TITLE
Add deep-linking support

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -380,9 +380,23 @@
         }
 
         formatStats();
+
+        document.querySelectorAll('.reviewer-card').forEach(card => {
+            card.addEventListener('click', () => {
+                const slug = card.dataset.slug;
+                openDrawer(slug);
+                history.replaceState(null, '', `#${slug}`);
+            });
+        });
+
+        const slug = location.hash.slice(1);
+        if (slug && document.getElementById(slug)) {
+            openDrawer(slug);
+        }
     });
 
-    function openDrawer(url) {
+    function openDrawer(slug) {
+        const url = `/reviewers/${slug}/`;
         const drawer = document.getElementById('drawer');
         const content = document.getElementById('drawer-content');
         fetch(url)
@@ -405,6 +419,7 @@
         const drawer = document.getElementById('drawer');
         const content = document.getElementById('drawer-content');
         drawer.classList.remove('open');
+        history.replaceState(null, '', window.location.pathname);
         
         // Clear content after animation completes
         setTimeout(() => {

--- a/index.html
+++ b/index.html
@@ -40,11 +40,11 @@ layout: default
         <div class="reviewer-grid">
             {% assign sorted_reviewers = site.reviewers | sort: "comments_count" | reverse %}
             {% for reviewer in sorted_reviewers %}
-            <div class="reviewer-card"
+            {% assign slug = reviewer.url | remove: '/reviewers/' | remove: '/' %}
+            <div class="reviewer-card" id="{{ slug }}" data-slug="{{ slug }}"
                  data-repo="{{ reviewer.repository }}"
                  data-category="{{ reviewer.label }}"
-                 data-language="{{ reviewer.language }}"
-                 onclick="openDrawer('{{ reviewer.url }}')">
+                 data-language="{{ reviewer.language }}">
                 <div class="reviewer-header">
                     <div>
                         <h3 class="reviewer-title">{{ reviewer.title }}</h3>


### PR DESCRIPTION
## Summary
- support hash-based deep-linking for reviewer drawer
- add `data-slug` and `id` to reviewer cards
- auto-open drawer via hash in JS and update URL when clicking cards
- clear hash on drawer close

## Testing
- `BUNDLE_GEMFILE=gemfile bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_6860d8621814832b89c846cd52eb5028