### PR TITLE
Add share buttons for reviewer links

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -464,7 +464,7 @@
         document.body.removeChild(textarea);
 
         button.classList.add('copied');
-        button.textContent = '✅ Copied';
+        button.textContent = 'Copied!';
 
         setTimeout(() => {
             button.classList.remove('copied');

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -452,6 +452,35 @@
             copyText.textContent = 'Copy Prompt';
         }, 2000);
     }
+
+    function copyDeeplink(slug, button) {
+        const url = `${window.location.origin}${window.location.pathname}#${slug}`;
+
+        const textarea = document.createElement('textarea');
+        textarea.value = url;
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+
+        button.classList.add('copied');
+        button.textContent = '✅ Copied';
+
+        setTimeout(() => {
+            button.classList.remove('copied');
+            button.textContent = 'Share';
+        }, 2000);
+    }
+
+    function shareFromCard(e, slug) {
+        e.stopPropagation();
+        copyDeeplink(slug, e.currentTarget);
+    }
+
+    function shareFromDrawer(e) {
+        const slug = location.hash.slice(1);
+        copyDeeplink(slug, e.currentTarget);
+    }
 </script>
 </body>
 </html>

--- a/_layouts/reviewer.html
+++ b/_layouts/reviewer.html
@@ -56,6 +56,7 @@ layout: default
                     </svg>
                     <span id="copy-text">Copy Prompt</span>
                 </button>
+                <button class="share-button" onclick="shareFromDrawer(event)">Share</button>
             </div>
         </div>
 
@@ -100,6 +101,27 @@ layout: default
         setTimeout(() => {
             copyButton.classList.remove('copied');
             copyText.textContent = 'Copy Prompt';
+        }, 2000);
+    }
+
+    function shareFromDrawer(e) {
+        const slug = location.hash.slice(1);
+        const button = e.currentTarget;
+        const url = `${window.location.origin}${window.location.pathname}#${slug}`;
+
+        const textarea = document.createElement('textarea');
+        textarea.value = url;
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+
+        button.classList.add('copied');
+        button.textContent = '✅ Copied';
+
+        setTimeout(() => {
+            button.classList.remove('copied');
+            button.textContent = 'Share';
         }, 2000);
     }
 </script>

--- a/_layouts/reviewer.html
+++ b/_layouts/reviewer.html
@@ -56,7 +56,7 @@ layout: default
                     </svg>
                     <span id="copy-text">Copy Prompt</span>
                 </button>
-                <button class="share-button" onclick="shareFromDrawer(event)">Share</button>
+                <button class="share-button copy-button" onclick="shareFromDrawer(event)">Share</button>
             </div>
         </div>
 
@@ -117,7 +117,7 @@ layout: default
         document.body.removeChild(textarea);
 
         button.classList.add('copied');
-        button.textContent = '✅ Copied';
+        button.textContent = 'Copied!';
 
         setTimeout(() => {
             button.classList.remove('copied');

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -571,6 +571,10 @@ h1, h2, h3, h4, h5, h6 {
     transition: background-color 0.2s ease;
 }
 
+.share-button:hover {
+    background: var(--bg-secondary);
+}
+
 .button-group .share-button {
     padding: 0.5rem 1rem;
     border-radius: 6px;
@@ -578,10 +582,16 @@ h1, h2, h3, h4, h5, h6 {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    border: none;
+    font-weight: 500;
+    cursor: pointer;
+    background: var(--accent);
+    color: #fff;
+    transition: background-color 0.2s ease;
 }
 
-.share-button:hover {
-    background: var(--bg-secondary);
+.button-group .share-button:hover {
+    background: var(--accent-hover);
 }
 
 .reviewer-card .share-button {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -575,24 +575,6 @@ h1, h2, h3, h4, h5, h6 {
     background: var(--bg-secondary);
 }
 
-.button-group .share-button {
-    padding: 0.5rem 1rem;
-    border-radius: 6px;
-    font-size: 0.875rem;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    border: none;
-    font-weight: 500;
-    cursor: pointer;
-    background: var(--accent);
-    color: #fff;
-    transition: background-color 0.2s ease;
-}
-
-.button-group .share-button:hover {
-    background: var(--accent-hover);
-}
 
 .reviewer-card .share-button {
     position: absolute;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -560,6 +560,27 @@ h1, h2, h3, h4, h5, h6 {
     color: #000000;
 }
 
+.share-button {
+    background: none;
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.share-button:hover {
+    background: var(--bg-secondary);
+}
+
+.reviewer-card .share-button {
+    position: absolute;
+    bottom: 1rem;
+    right: 1rem;
+}
+
 /* Footer */
 .footer {
     background: var(--bg-secondary);

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -571,6 +571,15 @@ h1, h2, h3, h4, h5, h6 {
     transition: background-color 0.2s ease;
 }
 
+.button-group .share-button {
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
 .share-button:hover {
     background: var(--bg-secondary);
 }

--- a/index.html
+++ b/index.html
@@ -75,6 +75,7 @@ layout: default
                         <span class="tag">{{ reviewer.label }}</span>
                         <span class="tag language">{{ reviewer.language }}</span>
                     </div>
+                    <button class="share-button" onclick="shareFromCard(event, '{{ slug }}')">Share</button>
                 </div>
             </div>
             {% endfor %}


### PR DESCRIPTION
# User description
## Summary
- allow sharing reviewer deep links from cards and drawer
- style new share button
- add clipboard helper functions

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6860dc23cfec832ba9c75d6de2abe555

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Implement share functionality by adding share buttons to reviewer cards and drawer views that copy deep links to clipboard when clicked. Add clipboard helper functions <code>copyDeeplink</code>, <code>shareFromCard</code>, and <code>shareFromDrawer</code> along with styling for the new share buttons.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Enable-deep-linking-fo...</td><td>June 29, 2025</td></tr>
<tr><td>nimrodkor</td><td>Extract-CSS</td><td>June 26, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Join @guyeisenkot and the rest of your team on <a href=https://main.baz.ninja/changes/baz-scm/awesome-reviewers/10?tool=ast>(Baz)</a>.