### PR TITLE
Add reviewer prompt download dropdown

### DIFF
--- a/_layouts/reviewer.html
+++ b/_layouts/reviewer.html
@@ -57,6 +57,14 @@ layout: default
                     <span id="copy-text">Copy Prompt</span>
                 </button>
                 <button class="share-button copy-button" onclick="shareFromDrawer(event)">Share</button>
+                <select id="download-select" class="download-select" onchange="downloadPrompt(this)">
+                    <option selected disabled>Download ▼</option>
+                    <option value="cursor">Cursor (.cursorrules)</option>
+                    <option value="windsurf">Windsurf (.windsurfrules)</option>
+                    <option value="claude">Claude (Markdown)</option>
+                    <option value="codex">Codex (Markdown)</option>
+                    <option value="copilot">Copilot (Markdown)</option>
+                </select>
             </div>
         </div>
 
@@ -123,5 +131,53 @@ layout: default
             button.classList.remove('copied');
             button.textContent = 'Share';
         }, 2000);
+    }
+
+    function downloadPrompt(select) {
+        const format = select.value;
+        if (!format) return;
+
+        const rawUrl = 'https://raw.githubusercontent.com/baz-scm/awesome-reviewers/main/{{ page.path }}';
+
+        fetch(rawUrl)
+            .then(res => res.text())
+            .then(text => {
+                const content = text.replace(/^---[\s\S]*?---\s*/, '');
+                let fileBase = '{{ page.path | split: "/" | last | replace: ".md", "" }}';
+                let output = content;
+                let filename = fileBase;
+
+                switch (format) {
+                    case 'cursor':
+                        output = `description: "{{ page.description | strip_newlines | escape }}"\nalwaysApply: false\n\n${content}`;
+                        filename += '.cursorrules';
+                        break;
+                    case 'windsurf':
+                        filename += '.windsurfrules';
+                        break;
+                    case 'claude':
+                        filename += '-claude.md';
+                        break;
+                    case 'codex':
+                        filename += '-codex.md';
+                        break;
+                    case 'copilot':
+                        filename += '-copilot.md';
+                        break;
+                    default:
+                        return;
+                }
+
+                const blob = new Blob([output], { type: 'text/markdown' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = filename;
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+                URL.revokeObjectURL(url);
+                select.value = '';
+            });
     }
 </script>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -861,6 +861,16 @@ h1, h2, h3, h4, h5, h6 {
     background: var(--border);
 }
 
+.download-select {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    color: var(--text-primary);
+    padding: 0.5rem 1rem;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    cursor: pointer;
+}
+
 .reviewer-prompt {
     background: var(--bg-secondary);
     border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- offer a download dropdown for various tool formats
- add matching styles
- fetch raw prompts from GitHub and download with the right extension

## Testing
- `BUNDLE_GEMFILE=gemfile bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_686239f5612c832b9d52ee64f6aeaac1