### PR TITLE
Fix Liquid syntax in reviewer file

### DIFF
--- a/_reviewers/deeplearning4j-use-modern-api-methods.md
+++ b/_reviewers/deeplearning4j-use-modern-api-methods.md
@@ -15,6 +15,7 @@ When implementing algorithms with numerical libraries like ND4J, always prefer t
 Key practices:
 1. Use `createFromArray` instead of `create` for array initialization, as it has clear overloads for all primitive types:
 ```java
+{% raw %}
 // Preferred:
 double arr_2d[][] = {{1.0,2.0,3.0},{4.0,5.0,6.0}};
 INDArray x_2d = Nd4j.createFromArray(arr_2d);
@@ -23,6 +24,7 @@ INDArray x_2d = Nd4j.createFromArray(arr_2d);
 double[] flat = ArrayUtil.flattenDoubleArray(myDoubleArray);
 int[] shape = {rows, cols};
 INDArray myArr = Nd4j.create(flat, shape, 'c');
+{% endraw %}
 ```
 
 2. Prefer direct parameter methods over shape arrays for common operations:


### PR DESCRIPTION
# User description
## Summary
- escape Liquid syntax in deeplearning4j reviewer

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_686a65e21ca0832b85a9d4afefe01369

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add Liquid template syntax escaping to prevent Jekyll from interpreting Java code examples as Liquid templates in the deeplearning4j reviewer guide. Fix the Jekyll build process by wrapping code blocks containing curly braces with <code>{% raw %}</code> tags.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>internal-baz-ci-app[bot]</td><td>Add-33-awesome-reviewe...</td><td>July 06, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Join @guyeisenkot and the rest of your team on <a href=https://main.baz.ninja/changes/baz-scm/awesome-reviewers/20?tool=ast>(Baz)</a>.