### PR TITLE
Fix deploy button handler

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -439,6 +439,7 @@
         }, 300);
     }
 
+    function deployToBaz() {
         console.log('🚀 Deploy to baz clicked');
         
         // Get the current reviewer slug from the URL hash


### PR DESCRIPTION
## Summary
- define `deployToBaz()` that was missing from default layout

## Testing
- `python3 migrate_json.py`
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686a68312c98832b8a8959fee428e063