### PR TITLE
Add full page links for reviewers

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -779,6 +779,32 @@ h1, h2, h3, h4, h5, h6 {
     right: 1rem;
 }
 
+.reviewer-card .card-actions {
+    position: absolute;
+    bottom: 1rem;
+    right: 1rem;
+    display: flex;
+    gap: 0.5rem;
+}
+
+.reviewer-card .card-actions .share-button {
+    position: static;
+}
+
+.fullpage-button {
+    border: 1px solid var(--border);
+    padding: 0.25rem 0.5rem;
+    font-size: 0.75rem;
+    border-radius: 4px;
+    text-decoration: none;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.fullpage-button:hover {
+    background: var(--bg-secondary);
+}
+
 /* Footer */
 .footer {
     background: var(--bg-secondary);

--- a/index.html
+++ b/index.html
@@ -77,7 +77,10 @@ layout: default
                         <span class="tag">{{ reviewer.label }}</span>
                         <span class="tag language">{{ reviewer.language }}</span>
                     </div>
-                    <button class="share-button" onclick="shareFromCard(event, '{{ slug }}')">Share</button>
+                    <div class="card-actions">
+                        <a href="{{ reviewer.url }}" class="fullpage-button" onclick="event.stopPropagation()">Full Page</a>
+                        <button class="share-button" onclick="shareFromCard(event, '{{ slug }}')">Share</button>
+                    </div>
                 </div>
             </div>
             {% endfor %}


### PR DESCRIPTION
## Summary
- add Full Page button to each reviewer card
- style card action container and new link

## Testing
- `bundle install --gemfile gemfile --quiet` *(fails: bundler aborted before installing jekyll)*
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687e29c4a674832bb455a5f0d164b8bc