### PR TITLE
Add contributor detail drawer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -504,7 +504,7 @@
     // Add event listeners when DOM is loaded
     document.addEventListener('DOMContentLoaded', function () {
         const searchInput = document.getElementById('search');
-        
+
         if (searchInput) searchInput.addEventListener('input', filterReviewers);
 
         // Initialize multi-select filters if containers exist
@@ -538,13 +538,15 @@
 
         formatStats();
 
-        // Load filters from URL parameters
-        loadFiltersFromUrl();
+        if (searchInput) {
+            // Load filters from URL parameters
+            loadFiltersFromUrl();
 
-        // Format initial reviewer count and apply filters
-        const initialCount = document.querySelectorAll('.reviewer-card').length;
-        updateReviewerCount(initialCount);
-        filterReviewers();
+            // Format initial reviewer count and apply filters
+            const initialCount = document.querySelectorAll('.reviewer-card').length;
+            updateReviewerCount(initialCount);
+            filterReviewers();
+        }
 
         document.querySelectorAll('.reviewer-card').forEach(card => {
             card.addEventListener('click', () => {
@@ -554,10 +556,22 @@
             });
         });
 
+        document.querySelectorAll('.contributor-card').forEach(card => {
+            card.addEventListener('click', () => {
+                const user = card.dataset.user;
+                openContributorDrawer(user);
+                history.replaceState(null, '', `#${user}`);
+            });
+        });
+
 
         const slug = location.hash.slice(1);
-        if (slug && document.getElementById(slug)) {
-            openDrawer(slug);
+        if (slug) {
+            if (document.querySelector(`.contributor-card[data-user="${slug}"]`)) {
+                openContributorDrawer(slug);
+            } else if (document.getElementById(slug)) {
+                openDrawer(slug);
+            }
         }
     });
 
@@ -585,6 +599,45 @@
                     highlightNewContent(content);
                 }
             });
+    }
+
+    function openContributorDrawer(user) {
+        const drawer = document.getElementById('drawer');
+        const content = document.getElementById('drawer-content');
+        const data = window.contributorsData ? window.contributorsData[user] : null;
+        if (!data) return;
+
+        const repoLinks = data.repos.map(r => `<li><a href='/?repos=${encodeURIComponent(r)}' target='_blank' rel='noopener noreferrer'>${r}</a></li>`).join('');
+        const entryLinks = data.entries.map(e => `<li><a href='/reviewers/${e.slug}/' target='_blank' rel='noopener noreferrer'>${e.title}</a></li>`).join('');
+
+        let commentsHtml = '';
+        for (const slug in data.comments) {
+            const comments = data.comments[slug];
+            const entry = data.entries.find(e => e.slug === slug);
+            const title = entry ? entry.title : slug;
+            const body = comments.map(c => `<p>&ndash; ${c}</p>`).join('');
+            commentsHtml += `<details class='comment-group'><summary class='comment-group-header'>${title} (${comments.length} comments)</summary><div class='comment-group-body'>${body}</div></details>`;
+        }
+
+        content.innerHTML = `
+            <div class='contributor-detail'>
+                <h2>@${user}</h2>
+                <details class='detail-section' open>
+                    <summary>Repositories</summary>
+                    <ul>${repoLinks}</ul>
+                </details>
+                <details class='detail-section'>
+                    <summary>Reviewer Entries</summary>
+                    <ul>${entryLinks}</ul>
+                </details>
+                <details class='detail-section'>
+                    <summary>Comments</summary>
+                    ${commentsHtml}
+                </details>
+            </div>
+        `;
+
+        drawer.classList.add('open');
     }
 
     function closeDrawer() {

--- a/_plugins/contributor_details_generator.rb
+++ b/_plugins/contributor_details_generator.rb
@@ -1,0 +1,59 @@
+require 'json'
+require 'set'
+
+module Jekyll
+  class ContributorDetailsGenerator < Generator
+    safe true
+    priority :high
+
+    def generate(site)
+      contributors = Hash.new { |h, k| h[k] = { 'repos' => Set.new, 'entries' => {}, 'comments' => Hash.new { |hh, kk| hh[kk] = [] } } }
+
+      # Map reviewer slug to title and repository from collection docs
+      metadata = {}
+      if site.collections['reviewers']
+        site.collections['reviewers'].docs.each do |doc|
+          slug = doc.basename_without_ext
+          metadata[slug] = {
+            'title' => doc.data['title'],
+            'repository' => doc.data['repository']
+          }
+        end
+      end
+
+      Dir.glob(File.join(site.source, '_reviewers', '*.json')) do |json_file|
+        slug = File.basename(json_file, '.json')
+        entry_meta = metadata[slug] || {}
+        entry_title = entry_meta['title']
+        default_repo = entry_meta['repository']
+
+        JSON.parse(File.read(json_file)).each do |discussion|
+          next unless discussion['discussion_comments']
+          discussion['discussion_comments'].each do |comment|
+            user = comment['comment_author']
+            next if user.nil? || user.include?('[bot]')
+            repo = comment['repo_full_name'] || default_repo
+            body = comment['comment_body']
+            info = contributors[user]
+            info['repos'] << repo if repo
+            info['entries'][slug] = entry_title if entry_title
+            if body && !body.strip.empty?
+              info['comments'][slug] << body
+            end
+          end
+        end
+      end
+
+      result = {}
+      contributors.each do |user, info|
+        result[user] = {
+          'repos' => info['repos'].to_a.sort,
+          'entries' => info['entries'].map { |s, t| { 'slug' => s, 'title' => t } },
+          'comments' => info['comments']
+        }
+      end
+
+      site.data['contributors'] = result
+    end
+  end
+end

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1593,3 +1593,45 @@ h2 .stat-value {
     padding-top: 1rem;
 }
 
+
+.contributor-detail h2 {
+    margin: 1rem;
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.detail-section {
+    border-top: 1px solid var(--border);
+    padding: 1rem;
+}
+.detail-section:first-of-type {
+    border-top: none;
+}
+.detail-section summary {
+    cursor: pointer;
+    font-weight: 500;
+    list-style: none;
+}
+.detail-section summary::-webkit-details-marker {
+    display: none;
+}
+.detail-section ul {
+    margin-top: 0.5rem;
+    padding-left: 1rem;
+    list-style: disc;
+}
+.comment-group-header {
+    cursor: pointer;
+    font-weight: 500;
+    list-style: none;
+}
+.comment-group-header::-webkit-details-marker {
+    display: none;
+}
+.comment-group-body {
+    padding-left: 1rem;
+    margin-top: 0.5rem;
+}
+.comment-group-body p {
+    margin-bottom: 0.5rem;
+}

--- a/leaderboard.md
+++ b/leaderboard.md
@@ -17,7 +17,7 @@ permalink: /leaderboard/
     <div class="reviewer-grid">
       {% assign top_contributors = site.data.leaderboard %}
       {% for contributor in top_contributors %}
-      <div class="reviewer-card contributor-card">
+      <div class="reviewer-card contributor-card" id="{{ contributor.user }}" data-user="{{ contributor.user }}">
         {% if forloop.index0 == 0 %}
           <span class="badge gold">🥇</span>
         {% elsif forloop.index0 == 1 %}
@@ -37,3 +37,17 @@ permalink: /leaderboard/
     </div>
   </div>
 </main>
+
+<div id="drawer" class="drawer">
+  <div class="drawer-overlay" onclick="closeDrawer()"></div>
+  <div class="drawer-panel">
+    <div class="drawer-header">
+      <button class="drawer-close" onclick="closeDrawer()">&times;</button>
+    </div>
+    <div id="drawer-content"></div>
+  </div>
+</div>
+
+<script>
+window.contributorsData = {{ site.data.contributors | jsonify }};
+</script>


### PR DESCRIPTION
## Summary
- add plugin to collect contributor data
- attach drawer markup on leaderboard page with contributor data script
- handle contributor-card behavior in default JS
- add details/accordion styling for contributor drawer

## Testing
- `bundle exec jekyll build -q` *(fails: unhandled exception)*

------
https://chatgpt.com/codex/tasks/task_b_687f4c1945e8832b87bdab4dcf6de302