### PR TITLE
Add fetch error handling

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -570,7 +570,12 @@
         const drawer = document.getElementById('drawer');
         const content = document.getElementById('drawer-content');
         fetch(url)
-            .then(r => r.text())
+            .then(res => {
+                if (!res.ok) {
+                    throw new Error(`Server returned ${res.status} ${res.statusText}`);
+                }
+                return res.text();
+            })
             .then(html => {
                 const doc = new DOMParser().parseFromString(html, 'text/html');
                 const detail = doc.querySelector('.reviewer-detail');
@@ -588,6 +593,9 @@
                 if (typeof highlightNewContent === 'function') {
                     highlightNewContent(content);
                 }
+            })
+            .catch(err => {
+                console.error('Fetch failed:', err);
             });
     }
 

--- a/_layouts/reviewer.html
+++ b/_layouts/reviewer.html
@@ -87,8 +87,16 @@ layout: default
     const threadEl = document.getElementById('discussion-thread');
     if (!threadEl) return;
     fetch("{{ '/reviewers/' | append: page.slug | append: '.json' | relative_url }}")
-      .then(r => r.json())
-      .then(blocks => renderDiscussion(threadEl, blocks));
+      .then(res => {
+        if (!res.ok) {
+          throw new Error(`Server returned ${res.status} ${res.statusText}`);
+        }
+        return res.json();
+      })
+      .then(blocks => renderDiscussion(threadEl, blocks))
+      .catch(err => {
+        console.error('Fetch failed:', err);
+      });
 
     function parseDiff(str) {
       if (!str) return [];


### PR DESCRIPTION
# User description
## Summary
- verify JSON path exists for `terraform-use-environment-variables.json`
- add robust error handling before parsing fetch responses

## Testing
- `ls -1 _reviewers/terraform-use-environment-variables.json`

------
https://chatgpt.com/codex/tasks/task_b_687f7b1c2b38832b8df6513ebd3f344a

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhance fetch operations in layout templates by adding comprehensive error handling for HTTP responses. The changes improve robustness of data loading in <code>default.html</code> and <code>reviewer.html</code> layouts by validating response status and providing error logging when fetch operations fail.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>fix-search-input-null-...</td><td>July 22, 2025</td></tr>
<tr><td>nimrodkor</td><td>Better-search-function...</td><td>July 10, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Join @guyeisenkot and the rest of your team on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/36?tool=ast>(Baz)</a>.