### PR TITLE
Implement contributor drawer

### DIFF
--- a/_plugins/leaderboard_generator.rb
+++ b/_plugins/leaderboard_generator.rb
@@ -1,13 +1,26 @@
 require 'json'
 require 'set'
+require 'yaml'
+require 'fileutils'
 
 module Jekyll
   class LeaderboardGenerator < Generator
     safe true
     priority :high
 
+
     def generate(site)
       contributors = {}
+      reviewer_meta = {}
+
+      Dir.glob(File.join(site.source, '_reviewers', '*.md')) do |md_file|
+        slug = File.basename(md_file, '.md')
+        data = YAML.load_file(md_file)
+        reviewer_meta[slug] = {
+          'title' => data['title'],
+          'repository' => data['repository']
+        }
+      end
 
       Dir.glob(File.join(site.source, '_reviewers', '*.json')) do |json_file|
         data = JSON.parse(File.read(json_file))
@@ -19,10 +32,16 @@ module Jekyll
             user = comment['comment_author']
             next if user.nil? || user.include?('[bot]')
 
-            repo = comment['repo_full_name'] || site.data.dig('reviewers', entry_slug, 'repository')
-            contributors[user] ||= { 'entries' => Set.new, 'repos' => Set.new }
+            repo = comment['repo_full_name'] || reviewer_meta.dig(entry_slug, 'repository')
+            contributors[user] ||= {
+              'entries' => Set.new,
+              'repos' => Set.new,
+              'comments' => Hash.new { |h, k| h[k] = [] }
+            }
             contributors[user]['entries'] << entry_slug
             contributors[user]['repos'] << repo if repo
+            body = comment['comment_body']
+            contributors[user]['comments'][entry_slug] << body if body
           end
         end
       end
@@ -40,6 +59,33 @@ module Jekyll
       leaderboard = leaderboard.first(50)
 
       site.data['leaderboard'] = leaderboard
+
+      contributors_data = {}
+      contributors.each do |user, info|
+        entries = info['entries'].map do |slug|
+          {
+            'slug' => slug,
+            'title' => reviewer_meta.dig(slug, 'title')
+          }
+        end
+
+        contributors_data[user] = {
+          'repos' => info['repos'].to_a,
+          'entries' => entries,
+          'comments' => info['comments']
+        }
+      end
+
+      site.data['contributors'] = contributors_data
+      site.config['contributors_data'] = contributors_data
     end
   end
+end
+
+Jekyll::Hooks.register :site, :post_write do |site|
+  data = site.config['contributors_data']
+  next unless data
+  dest_dir = File.join(site.dest, 'assets', 'data')
+  FileUtils.mkdir_p(dest_dir)
+  File.write(File.join(dest_dir, 'contributors.json'), JSON.pretty_generate(data))
 end

--- a/assets/js/leaderboard.js
+++ b/assets/js/leaderboard.js
@@ -1,0 +1,59 @@
+document.addEventListener('DOMContentLoaded', () => {
+  let contributors = {};
+  fetch('/assets/data/contributors.json')
+    .then(res => res.json())
+    .then(data => {
+      contributors = data;
+      attachListeners();
+      const user = location.hash.slice(1);
+      if (user && contributors[user]) {
+        openContributorDrawer(user);
+      }
+    });
+
+  function attachListeners() {
+    document.querySelectorAll('.contributor-card').forEach(card => {
+      card.addEventListener('click', () => {
+        const user = card.dataset.contributor;
+        if (user) {
+          openContributorDrawer(user);
+        }
+      });
+    });
+  }
+
+  function openContributorDrawer(user) {
+    const drawer = document.getElementById('drawer');
+    const content = document.getElementById('drawer-content');
+    const data = contributors[user];
+    if (!data) return;
+
+    history.replaceState(null, '', `#${user}`);
+
+    const repos = data.repos.map(r => `<li><a href='/?repo=${encodeURIComponent(r)}' target='_blank' rel='noopener noreferrer'>${r}</a></li>`).join('');
+    const entries = data.entries.map(e => `<li><a href='/reviewers/${e.slug}/' target='_blank' rel='noopener noreferrer'>${e.title}</a></li>`).join('');
+    const comments = Object.entries(data.comments).map(([slug, list]) => {
+      const entry = data.entries.find(e => e.slug === slug);
+      const title = entry ? entry.title : slug;
+      const items = list.map(text => `<li>${text}</li>`).join('');
+      return `<details><summary>${title}</summary><ul>${items}</ul></details>`;
+    }).join('');
+
+    content.innerHTML = `
+      <h2 class='mb-2 font-semibold'>@${user}</h2>
+      <details open>
+        <summary class='font-medium cursor-pointer'>Repositories</summary>
+        <ul class='ml-4 list-disc'>${repos}</ul>
+      </details>
+      <details open>
+        <summary class='font-medium cursor-pointer'>Reviewer Entries</summary>
+        <ul class='ml-4 list-disc'>${entries}</ul>
+      </details>
+      <details>
+        <summary class='font-medium cursor-pointer'>Comments</summary>
+        <div class='ml-4 space-y-2'>${comments}</div>
+      </details>`;
+
+    drawer.classList.add('open');
+  }
+});

--- a/leaderboard.md
+++ b/leaderboard.md
@@ -17,7 +17,7 @@ permalink: /leaderboard/
     <div class="reviewer-grid">
       {% assign top_contributors = site.data.leaderboard %}
       {% for contributor in top_contributors %}
-      <div class="reviewer-card contributor-card">
+      <div class="reviewer-card contributor-card" data-contributor="{{ contributor.user }}" id="{{ contributor.user }}">
         {% if forloop.index0 == 0 %}
           <span class="badge gold">🥇</span>
         {% elsif forloop.index0 == 1 %}
@@ -37,3 +37,15 @@ permalink: /leaderboard/
     </div>
   </div>
 </main>
+
+<div id="drawer" class="drawer">
+  <div class="drawer-overlay" onclick="closeDrawer()"></div>
+  <div class="drawer-panel">
+    <div class="drawer-header">
+      <button class="drawer-close" onclick="closeDrawer()">&times;</button>
+    </div>
+    <div id="drawer-content"></div>
+  </div>
+</div>
+
+<script src="{{ '/assets/js/leaderboard.js' | relative_url }}"></script>


### PR DESCRIPTION
## Summary
- generate contributor metadata during build and output `contributors.json`
- allow leaderboard cards to open a drawer with repos, entries, and comments
- implement JS logic to load `contributors.json` and populate the drawer

## Testing
- `BUNDLE_GEMFILE=gemfile bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_687f833b359c832b81f729c399917dc3