### PR TITLE
Fix asset URLs for GitHub Pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -22,13 +22,13 @@
 
     <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
     <meta name="description" content="{{ page.description | default: site.description }}">
-    <link rel="icon" type="image/x-icon" href="/favicon.png">
+    <link rel="icon" type="image/x-icon" href="{{ '/favicon.png' | relative_url }}">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
     <link rel="stylesheet" href="{{ '/assets/prism/prism.css' | relative_url }}">
-    <link rel="manifest" href="/manifest.json">
+    <link rel="manifest" href="{{ '/manifest.json' | relative_url }}">
     <link rel="canonical" href="{{ site.url }}{{ page.url }}">
 
     <!-- Google tag (gtag.js) -->
@@ -85,8 +85,8 @@
             </div>
             <a href="https://baz.co" class="logo" target="_blank" rel="noopener noreferrer" aria-label="Visit Baz Technologies homepage">
                 <div class="logo-icon">
-                    <img src="/assets/images/baz-light.svg" alt="Baz Technologies Logo" class="logo-light" width="80" height="80">
-                    <img src="/assets/images/baz-dark.svg" alt="Baz Technologies Logo" class="logo-dark" width="80" height="80"
+                    <img src="{{ '/assets/images/baz-light.svg' | relative_url }}" alt="Baz Technologies Logo" class="logo-light" width="80" height="80">
+                    <img src="{{ '/assets/images/baz-dark.svg' | relative_url }}" alt="Baz Technologies Logo" class="logo-dark" width="80" height="80"
                          style="display: none;">
                 </div>
             </a>

--- a/manifest.json
+++ b/manifest.json
@@ -1,20 +1,22 @@
+---
+---
 {
   "name": "Awesome Reviewers",
   "short_name": "Reviewers",
   "description": "AI-powered code review prompts",
-  "start_url": "/",
+  "start_url": "{{ '/' | relative_url }}",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#444ac2",
   "icons": [
     {
-      "src": "/assets/images/ar-web-192.png",
+      "src": "{{ '/assets/images/ar-web-192.png' | relative_url }}",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "maskable any"
     },
     {
-      "src": "/assets/images/ar-web-512.png",
+      "src": "{{ '/assets/images/ar-web-512.png' | relative_url }}",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable any"


### PR DESCRIPTION
# User description
## Summary
- apply `relative_url` to logo, favicon, and manifest links
- add front matter to `manifest.json` and update icon paths

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_687fbc9ec0b8832b84de05118b3c4ba7

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fix asset URL paths for GitHub Pages deployment by applying Jekyll's <code>relative_url</code> filter to favicon, logo images, and manifest links in the <code>default.html</code> layout template. Update <code>manifest.json</code> with Jekyll front matter and relative URLs for start_url and icon paths to ensure proper functionality when deployed to GitHub Pages subdirectories.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Replace-highlight.js-w...</td><td>July 22, 2025</td></tr>
<tr><td>nimrodkor</td><td>Better-search-function...</td><td>July 10, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Join @guyeisenkot and the rest of your team on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/43?tool=ast>(Baz)</a>.