### PR TITLE
Fix JS filtering on pages without search

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -417,8 +417,10 @@
         let visibleCount = 0;
 
         cards.forEach(card => {
-            const title = card.querySelector('.reviewer-title').textContent.toLowerCase();
-            const description = card.querySelector('.reviewer-description').textContent.toLowerCase();
+            const titleEl = card.querySelector('.reviewer-title');
+            const descriptionEl = card.querySelector('.reviewer-description');
+            const title = titleEl ? titleEl.textContent.toLowerCase() : '';
+            const description = descriptionEl ? descriptionEl.textContent.toLowerCase() : '';
             const repo = card.dataset.repo;
             const category = card.dataset.category;
             const language = card.dataset.language;
@@ -506,61 +508,64 @@
 
     // Add event listeners when DOM is loaded
     document.addEventListener('DOMContentLoaded', function () {
-        const searchInput = document.getElementById('search');
-        
-        if (searchInput) searchInput.addEventListener('input', filterReviewers);
+        if (document.getElementById('search')) {
+            const searchInput = document.getElementById('search');
 
-        // Initialize multi-select filters if containers exist
-        const categoryContainer = document.getElementById('category-filter');
-        const repoContainer = document.getElementById('repo-filter');
-        const languageContainer = document.getElementById('language-filter');
+            if (searchInput) searchInput.addEventListener('input', filterReviewers);
 
-        if (categoryContainer) {
-            const categoryOptions = Array.from(document.querySelectorAll('[data-category]'))
-                .map(el => el.dataset.category)
-                .filter((v, i, a) => a.indexOf(v) === i)
-                .sort();
-            categoryFilter = new MultiSelect('category-filter', categoryOptions);
-        }
+            // Initialize multi-select filters if containers exist
+            const categoryContainer = document.getElementById('category-filter');
+            const repoContainer = document.getElementById('repo-filter');
+            const languageContainer = document.getElementById('language-filter');
 
-        if (repoContainer) {
-            const repoOptions = Array.from(document.querySelectorAll('[data-repo]'))
-                .map(el => el.dataset.repo)
-                .filter((v, i, a) => a.indexOf(v) === i)
-                .sort();
-            repoFilter = new MultiSelect('repo-filter', repoOptions);
-        }
+            if (categoryContainer) {
+                const categoryOptions = Array.from(document.querySelectorAll('[data-category]'))
+                    .map(el => el.dataset.category)
+                    .filter((v, i, a) => a.indexOf(v) === i)
+                    .sort();
+                categoryFilter = new MultiSelect('category-filter', categoryOptions);
+            }
 
-        if (languageContainer) {
-            const languageOptions = Array.from(document.querySelectorAll('[data-language]'))
-                .map(el => el.dataset.language)
-                .filter((v, i, a) => a.indexOf(v) === i)
-                .sort();
-            languageFilter = new MultiSelect('language-filter', languageOptions);
-        }
+            if (repoContainer) {
+                const repoOptions = Array.from(document.querySelectorAll('[data-repo]'))
+                    .map(el => el.dataset.repo)
+                    .filter((v, i, a) => a.indexOf(v) === i)
+                    .sort();
+                repoFilter = new MultiSelect('repo-filter', repoOptions);
+            }
 
-        formatStats();
+            if (languageContainer) {
+                const languageOptions = Array.from(document.querySelectorAll('[data-language]'))
+                    .map(el => el.dataset.language)
+                    .filter((v, i, a) => a.indexOf(v) === i)
+                    .sort();
+                languageFilter = new MultiSelect('language-filter', languageOptions);
+            }
 
-        // Load filters from URL parameters
-        loadFiltersFromUrl();
+            formatStats();
 
-        // Format initial reviewer count and apply filters
-        const initialCount = document.querySelectorAll('.reviewer-card').length;
-        updateReviewerCount(initialCount);
-        filterReviewers();
+            // Load filters from URL parameters
+            loadFiltersFromUrl();
 
-        document.querySelectorAll('.reviewer-card').forEach(card => {
-            card.addEventListener('click', () => {
-                const slug = card.dataset.slug;
-                openDrawer(slug);
-                history.replaceState(null, '', `#${slug}`);
+            // Format initial reviewer count and apply filters
+            const initialCount = document.querySelectorAll('.reviewer-card').length;
+            updateReviewerCount(initialCount);
+            filterReviewers();
+
+            document.querySelectorAll('.reviewer-card').forEach(card => {
+                if (card.dataset.slug) {
+                    card.addEventListener('click', () => {
+                        const slug = card.dataset.slug;
+                        openDrawer(slug);
+                        history.replaceState(null, '', `#${slug}`);
+                    });
+                }
             });
-        });
 
-
-        const slug = location.hash.slice(1);
-        if (slug && document.getElementById(slug)) {
-            openDrawer(slug);
+            const slug = location.hash.slice(1);
+            if (slug && document.getElementById(slug)) {
+                openDrawer(slug);
+            }
         }
     });
 


### PR DESCRIPTION
# User description
## Summary
- guard missing title/description on reviewer cards
- only init filtering when search bar is present
- avoid attaching click handlers to slugless reviewer cards

## Testing
- `bundle install --gemfile=gemfile`
- `BUNDLE_GEMFILE=gemfile bundle exec jekyll build --quiet`

------
https://chatgpt.com/codex/tasks/task_b_687fc7ffe6e0832b94acd7cb9ae72dea

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fixes JavaScript errors on pages without search functionality by adding defensive checks for missing DOM elements in the reviewer card filtering and interaction system. Guards against missing <code>title</code>/<code>description</code> elements on reviewer cards and conditionally initializes search filtering only when a search bar is present.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Fix-asset-URLs-to-resp...</td><td>July 22, 2025</td></tr>
<tr><td>nimrodkor</td><td>Better-search-function...</td><td>July 10, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Join @guyeisenkot and the rest of your team on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/44?tool=ast>(Baz)</a>.