### PR TITLE
Fix share button copy behavior

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -811,23 +811,31 @@
         }, 2000);
     }
 
-    function copyDeeplink(slug, button) {
+    async function copyDeeplink(slug, button) {
         const url = `${window.location.origin}${window.location.pathname}#${slug}`;
 
-        const textarea = document.createElement('textarea');
-        textarea.value = url;
-        document.body.appendChild(textarea);
-        textarea.select();
-        document.execCommand('copy');
-        document.body.removeChild(textarea);
+        try {
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                await navigator.clipboard.writeText(url);
+            } else {
+                const textarea = document.createElement('textarea');
+                textarea.value = url;
+                document.body.appendChild(textarea);
+                textarea.select();
+                document.execCommand('copy');
+                document.body.removeChild(textarea);
+            }
 
-        button.classList.add('copied');
-        button.textContent = 'Copied!';
-
-        setTimeout(() => {
-            button.classList.remove('copied');
-            button.textContent = 'Share';
-        }, 2000);
+            button.classList.add('copied');
+            button.textContent = 'Copied!';
+        } catch (err) {
+            console.error('Copy failed', err);
+        } finally {
+            setTimeout(() => {
+                button.classList.remove('copied');
+                button.textContent = 'Share';
+            }, 2000);
+        }
     }
 
     function shareFromCard(e, slug) {


### PR DESCRIPTION
## Summary
- update copy logic to use `navigator.clipboard` with fallback

## Testing
- `jekyll --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6880a2a39170832ba540a067cca9f9e7