### PR TITLE
Display source discussions in reviewer drawer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -566,6 +566,14 @@
                 openDrawer(slug);
             }
         }
+
+        if (document.getElementById('discussion-container')) {
+            const parts = location.pathname.split('/').filter(Boolean);
+            const pageSlug = parts[parts.length - 1];
+            if (pageSlug) {
+                loadDiscussions(pageSlug);
+            }
+        }
     });
 
     function openDrawer(slug) {
@@ -594,6 +602,7 @@
                 if (typeof highlightNewContent === 'function') {
                     highlightNewContent(content);
                 }
+                loadDiscussions(slug);
             })
             .catch(err => {
                 console.error('Fetch failed:', err);
@@ -836,6 +845,41 @@
                 button.textContent = 'Share';
             }, 2000);
         }
+    }
+
+    function loadDiscussions(slug) {
+        const container = document.getElementById('discussion-container');
+        if (!container) return;
+
+        fetch(`/_reviewers/${slug}.json`)
+            .then(res => res.json())
+            .then(data => {
+                container.innerHTML = data.map(renderDiscussion).join('');
+                if (typeof highlightNewContent === 'function') {
+                    highlightNewContent(container);
+                }
+            })
+            .catch(err => console.error('Failed to load discussions', err));
+    }
+
+    function renderDiscussion(d) {
+        const code = d.commented_code ?
+            `<pre class="discuss-code"><code>${escapeHtml(d.commented_code)}</code></pre>` : '';
+        const comments = (d.discussion_comments || []).map(renderComment).join('');
+        return `<div class="discussion">${code}<div class="chat-thread">${comments}</div></div>`;
+    }
+
+    function renderComment(c) {
+        const avatar = `https://github.com/${c.comment_author}.png?size=40`;
+        const body = escapeHtml(c.comment_body).replace(/\n/g, '<br>');
+        const time = new Date(c.comment_created_at).toLocaleDateString();
+        return `<div class="chat-message"><img class="chat-avatar" src="${avatar}" alt="${c.comment_author}"><div class="chat-bubble"><div class="chat-meta"><span class="chat-author">${c.comment_author}</span> <span class="chat-time">${time}</span></div><div class="chat-body">${body}</div></div></div>`;
+    }
+
+    function escapeHtml(str) {
+        const div = document.createElement('div');
+        div.textContent = str;
+        return div.innerHTML;
     }
 
     function shareFromCard(e, slug) {

--- a/_layouts/reviewer.html
+++ b/_layouts/reviewer.html
@@ -77,6 +77,11 @@ layout: default
             <div class="stat-label">Category</div>
         </div>
     </div>
+
+    <div class="discussions-section">
+        <h2 class="content-title">Source Discussions</h2>
+        <div id="discussion-container"></div>
+    </div>
 </div>
 
 <script>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1563,4 +1563,56 @@ h2 .stat-value {
     margin-right: 0.5rem;
 }
 
+/* Discussion styles */
+.discussions-section {
+    padding: 1.5rem;
+    border-top: 1px solid var(--border);
+}
+
+.discuss-code {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 1rem;
+    overflow: auto;
+    margin-bottom: 1rem;
+}
+
+.chat-thread {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.chat-message {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+}
+
+.chat-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+}
+
+.chat-bubble {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 0.5rem 0.75rem;
+    max-width: 100%;
+}
+
+.chat-meta {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    margin-bottom: 0.25rem;
+}
+
+.chat-body {
+    white-space: pre-wrap;
+    font-size: 0.875rem;
+}
+
 


### PR DESCRIPTION
## Summary
- add a new section in reviewer pages to show discussion data
- style discussion threads with chat-like layout
- load JSON discussion data when a reviewer is viewed in the drawer or directly

## Testing
- `bundle install --path vendor/bundle`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_68812a0da4dc832ba78872796fd25f8d