### PR TITLE
Filter bots from leaderboard

### DIFF
--- a/_data/leaderboard.json
+++ b/_data/leaderboard.json
@@ -1,27 +1,9 @@
 [
   {
-    "name": "Copilot",
-    "reviewers_count": 111,
-    "repos_count": 23,
-    "last_contribution": "2025-07-23T17:58:49+00:00"
-  },
-  {
-    "name": "ellipsis-dev[bot]",
-    "reviewers_count": 52,
-    "repos_count": 2,
-    "last_contribution": "2025-07-23T07:19:13+00:00"
-  },
-  {
     "name": "kimwnasptd",
     "reviewers_count": 44,
     "repos_count": 1,
     "last_contribution": "2023-10-26T14:36:41+00:00"
-  },
-  {
-    "name": "coderabbitai[bot]",
-    "reviewers_count": 39,
-    "repos_count": 3,
-    "last_contribution": "2025-07-08T12:09:10+00:00"
   },
   {
     "name": "Darksonn",
@@ -42,12 +24,6 @@
     "last_contribution": "2025-04-10T06:32:22+00:00"
   },
   {
-    "name": "graphite-app[bot]",
-    "reviewers_count": 29,
-    "repos_count": 2,
-    "last_contribution": "2025-07-13T08:33:30+00:00"
-  },
-  {
     "name": "jasnell",
     "reviewers_count": 27,
     "repos_count": 2,
@@ -66,16 +42,16 @@
     "last_contribution": "2025-07-02T13:38:28+00:00"
   },
   {
-    "name": "github-advanced-security[bot]",
-    "reviewers_count": 23,
-    "repos_count": 10,
-    "last_contribution": "2025-07-20T05:40:57+00:00"
-  },
-  {
-    "name": "gemini-code-assist[bot]",
+    "name": "jfagoagas",
     "reviewers_count": 22,
     "repos_count": 1,
-    "last_contribution": "2025-07-08T07:43:35+00:00"
+    "last_contribution": "2025-07-08T11:25:04+00:00"
+  },
+  {
+    "name": "Viicos",
+    "reviewers_count": 22,
+    "repos_count": 1,
+    "last_contribution": "2025-06-30T17:39:21+00:00"
   },
   {
     "name": "jkotas",
@@ -90,22 +66,28 @@
     "last_contribution": "2025-07-22T17:05:21+00:00"
   },
   {
-    "name": "jfagoagas",
-    "reviewers_count": 22,
+    "name": "MMeent",
+    "reviewers_count": 21,
     "repos_count": 1,
-    "last_contribution": "2025-07-08T11:25:04+00:00"
+    "last_contribution": "2025-07-08T13:51:47+00:00"
   },
   {
-    "name": "Viicos",
-    "reviewers_count": 22,
+    "name": "sydney-runkle",
+    "reviewers_count": 21,
     "repos_count": 1,
-    "last_contribution": "2025-06-30T17:39:21+00:00"
+    "last_contribution": "2025-03-03T16:08:01+00:00"
   },
   {
     "name": "wilkinsona",
     "reviewers_count": 21,
     "repos_count": 1,
     "last_contribution": "2025-06-26T07:22:59+00:00"
+  },
+  {
+    "name": "gruebel",
+    "reviewers_count": 21,
+    "repos_count": 1,
+    "last_contribution": "2025-04-21T20:21:17+00:00"
   },
   {
     "name": "Narsil",
@@ -120,46 +102,10 @@
     "last_contribution": "2025-06-25T07:53:27+00:00"
   },
   {
-    "name": "gruebel",
-    "reviewers_count": 21,
-    "repos_count": 1,
-    "last_contribution": "2025-04-21T20:21:17+00:00"
-  },
-  {
-    "name": "sydney-runkle",
-    "reviewers_count": 21,
-    "repos_count": 1,
-    "last_contribution": "2025-03-03T16:08:01+00:00"
-  },
-  {
-    "name": "MMeent",
-    "reviewers_count": 21,
-    "repos_count": 1,
-    "last_contribution": "2025-07-08T13:51:47+00:00"
-  },
-  {
     "name": "chris-olszewski",
     "reviewers_count": 20,
     "repos_count": 1,
     "last_contribution": "2025-07-07T16:00:13+00:00"
-  },
-  {
-    "name": "ololobus",
-    "reviewers_count": 19,
-    "repos_count": 1,
-    "last_contribution": "2025-07-04T18:59:02+00:00"
-  },
-  {
-    "name": "cubic-dev-ai[bot]",
-    "reviewers_count": 19,
-    "repos_count": 1,
-    "last_contribution": "2025-07-18T16:26:56+00:00"
-  },
-  {
-    "name": "treo",
-    "reviewers_count": 19,
-    "repos_count": 1,
-    "last_contribution": "2024-10-24T07:16:04+00:00"
   },
   {
     "name": "asmorkalov",
@@ -168,10 +114,16 @@
     "last_contribution": "2025-07-02T09:00:11+00:00"
   },
   {
-    "name": "jmcdo29",
+    "name": "treo",
     "reviewers_count": 19,
     "repos_count": 1,
-    "last_contribution": "2024-02-06T17:07:55+00:00"
+    "last_contribution": "2024-10-24T07:16:04+00:00"
+  },
+  {
+    "name": "ololobus",
+    "reviewers_count": 19,
+    "repos_count": 1,
+    "last_contribution": "2025-07-04T18:59:02+00:00"
   },
   {
     "name": "micalevisk",
@@ -180,16 +132,16 @@
     "last_contribution": "2025-04-20T00:06:02+00:00"
   },
   {
-    "name": "mwilsnd",
-    "reviewers_count": 18,
+    "name": "jmcdo29",
+    "reviewers_count": 19,
     "repos_count": 1,
-    "last_contribution": "2024-08-30T16:57:42+00:00"
+    "last_contribution": "2024-02-06T17:07:55+00:00"
   },
   {
-    "name": "VladLazar",
+    "name": "yottta",
     "reviewers_count": 18,
     "repos_count": 1,
-    "last_contribution": "2025-07-08T18:37:39+00:00"
+    "last_contribution": "2025-06-10T05:36:35+00:00"
   },
   {
     "name": "AlexDBlack",
@@ -204,16 +156,10 @@
     "last_contribution": "2025-06-25T06:56:07+00:00"
   },
   {
-    "name": "lgrammel",
+    "name": "VladLazar",
     "reviewers_count": 18,
     "repos_count": 1,
-    "last_contribution": "2025-07-08T16:32:34+00:00"
-  },
-  {
-    "name": "yottta",
-    "reviewers_count": 18,
-    "repos_count": 1,
-    "last_contribution": "2025-06-10T05:36:35+00:00"
+    "last_contribution": "2025-07-08T18:37:39+00:00"
   },
   {
     "name": "bolinfest",
@@ -222,28 +168,28 @@
     "last_contribution": "2025-07-22T22:54:11+00:00"
   },
   {
-    "name": "hiltontj",
-    "reviewers_count": 17,
+    "name": "lgrammel",
+    "reviewers_count": 18,
     "repos_count": 1,
-    "last_contribution": "2025-06-03T00:28:29+00:00"
+    "last_contribution": "2025-07-08T16:32:34+00:00"
   },
   {
-    "name": "dougwilson",
-    "reviewers_count": 17,
+    "name": "mwilsnd",
+    "reviewers_count": 18,
     "repos_count": 1,
-    "last_contribution": "2023-06-19T13:02:50+00:00"
-  },
-  {
-    "name": "SomeoneToIgnore",
-    "reviewers_count": 17,
-    "repos_count": 1,
-    "last_contribution": "2025-07-04T08:52:32+00:00"
+    "last_contribution": "2024-08-30T16:57:42+00:00"
   },
   {
     "name": "anthonyshew",
     "reviewers_count": 17,
     "repos_count": 1,
     "last_contribution": "2025-07-08T13:52:04+00:00"
+  },
+  {
+    "name": "SomeoneToIgnore",
+    "reviewers_count": 17,
+    "repos_count": 1,
+    "last_contribution": "2025-07-04T08:52:32+00:00"
   },
   {
     "name": "ZeeshanTamboli",
@@ -258,46 +204,16 @@
     "last_contribution": "2025-06-18T17:54:07+00:00"
   },
   {
-    "name": "myrrc",
-    "reviewers_count": 16,
+    "name": "dougwilson",
+    "reviewers_count": 17,
     "repos_count": 1,
-    "last_contribution": "2025-06-20T17:51:30+00:00"
+    "last_contribution": "2023-06-19T13:02:50+00:00"
   },
   {
-    "name": "konstin",
-    "reviewers_count": 16,
+    "name": "hiltontj",
+    "reviewers_count": 17,
     "repos_count": 1,
-    "last_contribution": "2025-07-01T12:06:55+00:00"
-  },
-  {
-    "name": "apparentlymart",
-    "reviewers_count": 16,
-    "repos_count": 1,
-    "last_contribution": "2025-07-07T16:30:38+00:00"
-  },
-  {
-    "name": "mattlord",
-    "reviewers_count": 16,
-    "repos_count": 1,
-    "last_contribution": "2025-05-02T16:47:14+00:00"
-  },
-  {
-    "name": "n1t0",
-    "reviewers_count": 16,
-    "repos_count": 1,
-    "last_contribution": "2021-12-14T13:19:40+00:00"
-  },
-  {
-    "name": "ste93cry",
-    "reviewers_count": 16,
-    "repos_count": 1,
-    "last_contribution": "2023-12-20T08:03:24+00:00"
-  },
-  {
-    "name": "sbrannen",
-    "reviewers_count": 16,
-    "repos_count": 1,
-    "last_contribution": "2025-06-18T10:02:06+00:00"
+    "last_contribution": "2025-06-03T00:28:29+00:00"
   },
   {
     "name": "jmorganca",
@@ -306,22 +222,16 @@
     "last_contribution": "2025-05-27T22:30:23+00:00"
   },
   {
-    "name": "pauldix",
-    "reviewers_count": 16,
-    "repos_count": 1,
-    "last_contribution": "2025-03-07T14:57:26+00:00"
-  },
-  {
-    "name": "agibsonccc",
-    "reviewers_count": 16,
-    "repos_count": 1,
-    "last_contribution": "2023-05-08T11:38:59+00:00"
-  },
-  {
     "name": "tristan957",
     "reviewers_count": 16,
     "repos_count": 2,
     "last_contribution": "2025-06-26T14:54:42+00:00"
+  },
+  {
+    "name": "myrrc",
+    "reviewers_count": 16,
+    "repos_count": 1,
+    "last_contribution": "2025-06-20T17:51:30+00:00"
   },
   {
     "name": "dnr",
@@ -330,22 +240,100 @@
     "last_contribution": "2025-07-18T04:05:29+00:00"
   },
   {
+    "name": "mattlord",
+    "reviewers_count": 16,
+    "repos_count": 1,
+    "last_contribution": "2025-05-02T16:47:14+00:00"
+  },
+  {
+    "name": "apparentlymart",
+    "reviewers_count": 16,
+    "repos_count": 1,
+    "last_contribution": "2025-07-07T16:30:38+00:00"
+  },
+  {
+    "name": "sbrannen",
+    "reviewers_count": 16,
+    "repos_count": 1,
+    "last_contribution": "2025-06-18T10:02:06+00:00"
+  },
+  {
     "name": "bo156",
     "reviewers_count": 16,
     "repos_count": 1,
     "last_contribution": "2025-06-23T12:57:22+00:00"
   },
   {
-    "name": "knizhnik",
+    "name": "n1t0",
+    "reviewers_count": 16,
+    "repos_count": 1,
+    "last_contribution": "2021-12-14T13:19:40+00:00"
+  },
+  {
+    "name": "konstin",
+    "reviewers_count": 16,
+    "repos_count": 1,
+    "last_contribution": "2025-07-01T12:06:55+00:00"
+  },
+  {
+    "name": "ste93cry",
+    "reviewers_count": 16,
+    "repos_count": 1,
+    "last_contribution": "2023-12-20T08:03:24+00:00"
+  },
+  {
+    "name": "agibsonccc",
+    "reviewers_count": 16,
+    "repos_count": 1,
+    "last_contribution": "2023-05-08T11:38:59+00:00"
+  },
+  {
+    "name": "pauldix",
+    "reviewers_count": 16,
+    "repos_count": 1,
+    "last_contribution": "2025-03-07T14:57:26+00:00"
+  },
+  {
+    "name": "cam72cam",
     "reviewers_count": 15,
     "repos_count": 1,
-    "last_contribution": "2025-07-09T10:27:31+00:00"
+    "last_contribution": "2025-05-15T16:07:13+00:00"
+  },
+  {
+    "name": "BruceMacD",
+    "reviewers_count": 15,
+    "repos_count": 1,
+    "last_contribution": "2025-06-03T18:34:57+00:00"
+  },
+  {
+    "name": "erikgrinaker",
+    "reviewers_count": 15,
+    "repos_count": 1,
+    "last_contribution": "2025-07-08T20:14:22+00:00"
+  },
+  {
+    "name": "oliviertassinari",
+    "reviewers_count": 15,
+    "repos_count": 1,
+    "last_contribution": "2025-05-08T21:14:43+00:00"
+  },
+  {
+    "name": "DiegoAndai",
+    "reviewers_count": 15,
+    "repos_count": 1,
+    "last_contribution": "2025-07-07T19:42:36+00:00"
   },
   {
     "name": "AdriiiPRodri",
     "reviewers_count": 15,
     "repos_count": 1,
     "last_contribution": "2025-06-25T08:14:21+00:00"
+  },
+  {
+    "name": "lzchen",
+    "reviewers_count": 15,
+    "repos_count": 1,
+    "last_contribution": "2025-03-18T19:17:11+00:00"
   },
   {
     "name": "chrisradek",
@@ -360,82 +348,16 @@
     "last_contribution": "2025-07-03T17:34:20+00:00"
   },
   {
-    "name": "BruceMacD",
-    "reviewers_count": 15,
-    "repos_count": 1,
-    "last_contribution": "2025-06-03T18:34:57+00:00"
-  },
-  {
-    "name": "cam72cam",
-    "reviewers_count": 15,
-    "repos_count": 1,
-    "last_contribution": "2025-05-15T16:07:13+00:00"
-  },
-  {
-    "name": "erikgrinaker",
-    "reviewers_count": 15,
-    "repos_count": 1,
-    "last_contribution": "2025-07-08T20:14:22+00:00"
-  },
-  {
-    "name": "DiegoAndai",
-    "reviewers_count": 15,
-    "repos_count": 1,
-    "last_contribution": "2025-07-07T19:42:36+00:00"
-  },
-  {
-    "name": "oliviertassinari",
-    "reviewers_count": 15,
-    "repos_count": 1,
-    "last_contribution": "2025-05-08T21:14:43+00:00"
-  },
-  {
-    "name": "lzchen",
-    "reviewers_count": 15,
-    "repos_count": 1,
-    "last_contribution": "2025-03-18T19:17:11+00:00"
-  },
-  {
     "name": "ollevche",
     "reviewers_count": 15,
     "repos_count": 1,
     "last_contribution": "2025-04-25T10:43:35+00:00"
   },
   {
-    "name": "DimasKovas",
-    "reviewers_count": 14,
+    "name": "knizhnik",
+    "reviewers_count": 15,
     "repos_count": 1,
-    "last_contribution": "2025-07-08T08:57:56+00:00"
-  },
-  {
-    "name": "pierrejeambrun",
-    "reviewers_count": 14,
-    "repos_count": 1,
-    "last_contribution": "2025-07-04T08:57:17+00:00"
-  },
-  {
-    "name": "davidspek",
-    "reviewers_count": 14,
-    "repos_count": 1,
-    "last_contribution": "2021-06-15T10:08:27+00:00"
-  },
-  {
-    "name": "Jarred-Sumner",
-    "reviewers_count": 14,
-    "repos_count": 1,
-    "last_contribution": "2025-07-14T04:54:52+00:00"
-  },
-  {
-    "name": "vicferpoy",
-    "reviewers_count": 14,
-    "repos_count": 1,
-    "last_contribution": "2025-07-08T11:26:35+00:00"
-  },
-  {
-    "name": "normanmaurer",
-    "reviewers_count": 14,
-    "repos_count": 1,
-    "last_contribution": "2025-06-27T14:19:21+00:00"
+    "last_contribution": "2025-07-09T10:27:31+00:00"
   },
   {
     "name": "Yantrio",
@@ -450,10 +372,46 @@
     "last_contribution": "2025-06-10T11:45:46+00:00"
   },
   {
-    "name": "mitchellh",
+    "name": "normanmaurer",
+    "reviewers_count": 14,
+    "repos_count": 1,
+    "last_contribution": "2025-06-27T14:19:21+00:00"
+  },
+  {
+    "name": "vicferpoy",
+    "reviewers_count": 14,
+    "repos_count": 1,
+    "last_contribution": "2025-07-08T11:26:35+00:00"
+  },
+  {
+    "name": "Jarred-Sumner",
+    "reviewers_count": 14,
+    "repos_count": 1,
+    "last_contribution": "2025-07-14T04:54:52+00:00"
+  },
+  {
+    "name": "pierrejeambrun",
+    "reviewers_count": 14,
+    "repos_count": 1,
+    "last_contribution": "2025-07-04T08:57:17+00:00"
+  },
+  {
+    "name": "DimasKovas",
+    "reviewers_count": 14,
+    "repos_count": 1,
+    "last_contribution": "2025-07-08T08:57:56+00:00"
+  },
+  {
+    "name": "davidspek",
+    "reviewers_count": 14,
+    "repos_count": 1,
+    "last_contribution": "2021-06-15T10:08:27+00:00"
+  },
+  {
+    "name": "patak-dev",
     "reviewers_count": 13,
     "repos_count": 1,
-    "last_contribution": "2025-07-06T04:40:31+00:00"
+    "last_contribution": "2025-05-01T06:00:29+00:00"
   },
   {
     "name": "Patrick-Erichsen",
@@ -462,10 +420,46 @@
     "last_contribution": "2025-07-23T01:38:26+00:00"
   },
   {
+    "name": "opencv-alalek",
+    "reviewers_count": 13,
+    "repos_count": 1,
+    "last_contribution": "2025-05-30T07:09:08+00:00"
+  },
+  {
+    "name": "Bo98",
+    "reviewers_count": 13,
+    "repos_count": 1,
+    "last_contribution": "2025-07-04T20:45:07+00:00"
+  },
+  {
+    "name": "mitchellh",
+    "reviewers_count": 13,
+    "repos_count": 1,
+    "last_contribution": "2025-07-06T04:40:31+00:00"
+  },
+  {
+    "name": "tsmithv11",
+    "reviewers_count": 13,
+    "repos_count": 1,
+    "last_contribution": "2025-05-13T20:15:00+00:00"
+  },
+  {
+    "name": "lucasgomide",
+    "reviewers_count": 13,
+    "repos_count": 1,
+    "last_contribution": "2025-07-02T17:55:03+00:00"
+  },
+  {
     "name": "praveen-influx",
     "reviewers_count": 13,
     "repos_count": 1,
     "last_contribution": "2025-06-02T15:30:42+00:00"
+  },
+  {
+    "name": "ChanochShayner",
+    "reviewers_count": 13,
+    "repos_count": 1,
+    "last_contribution": "2024-08-08T10:24:52+00:00"
   },
   {
     "name": "xrmx",
@@ -486,90 +480,6 @@
     "last_contribution": "2025-05-27T20:24:45+00:00"
   },
   {
-    "name": "opencv-alalek",
-    "reviewers_count": 13,
-    "repos_count": 1,
-    "last_contribution": "2025-05-30T07:09:08+00:00"
-  },
-  {
-    "name": "lucasgomide",
-    "reviewers_count": 13,
-    "repos_count": 1,
-    "last_contribution": "2025-07-02T17:55:03+00:00"
-  },
-  {
-    "name": "patak-dev",
-    "reviewers_count": 13,
-    "repos_count": 1,
-    "last_contribution": "2025-05-01T06:00:29+00:00"
-  },
-  {
-    "name": "tsmithv11",
-    "reviewers_count": 13,
-    "repos_count": 1,
-    "last_contribution": "2025-05-13T20:15:00+00:00"
-  },
-  {
-    "name": "ChanochShayner",
-    "reviewers_count": 13,
-    "repos_count": 1,
-    "last_contribution": "2024-08-08T10:24:52+00:00"
-  },
-  {
-    "name": "Bo98",
-    "reviewers_count": 13,
-    "repos_count": 1,
-    "last_contribution": "2025-07-04T20:45:07+00:00"
-  },
-  {
-    "name": "emdneto",
-    "reviewers_count": 12,
-    "repos_count": 1,
-    "last_contribution": "2025-06-23T23:54:27+00:00"
-  },
-  {
-    "name": "jcollie",
-    "reviewers_count": 12,
-    "repos_count": 1,
-    "last_contribution": "2025-07-06T00:17:29+00:00"
-  },
-  {
-    "name": "byroot",
-    "reviewers_count": 12,
-    "repos_count": 1,
-    "last_contribution": "2025-07-01T10:47:58+00:00"
-  },
-  {
-    "name": "190n",
-    "reviewers_count": 12,
-    "repos_count": 1,
-    "last_contribution": "2025-07-11T23:06:18+00:00"
-  },
-  {
-    "name": "shaedrich",
-    "reviewers_count": 12,
-    "repos_count": 1,
-    "last_contribution": "2025-06-17T14:21:26+00:00"
-  },
-  {
-    "name": "siriwatknp",
-    "reviewers_count": 12,
-    "repos_count": 1,
-    "last_contribution": "2025-07-01T07:50:21+00:00"
-  },
-  {
-    "name": "Janpot",
-    "reviewers_count": 12,
-    "repos_count": 1,
-    "last_contribution": "2025-07-03T08:22:30+00:00"
-  },
-  {
-    "name": "bracesproul",
-    "reviewers_count": 12,
-    "repos_count": 1,
-    "last_contribution": "2025-04-18T18:45:37+00:00"
-  },
-  {
     "name": "mox692",
     "reviewers_count": 12,
     "repos_count": 1,
@@ -588,15 +498,105 @@
     "last_contribution": "2025-04-07T21:34:17+00:00"
   },
   {
+    "name": "190n",
+    "reviewers_count": 12,
+    "repos_count": 1,
+    "last_contribution": "2025-07-11T23:06:18+00:00"
+  },
+  {
+    "name": "deepthi",
+    "reviewers_count": 12,
+    "repos_count": 1,
+    "last_contribution": "2025-06-30T20:26:44+00:00"
+  },
+  {
+    "name": "tknickman",
+    "reviewers_count": 12,
+    "repos_count": 1,
+    "last_contribution": "2025-01-14T19:18:55+00:00"
+  },
+  {
+    "name": "GuptaManan100",
+    "reviewers_count": 12,
+    "repos_count": 1,
+    "last_contribution": "2025-04-10T07:39:53+00:00"
+  },
+  {
+    "name": "legendecas",
+    "reviewers_count": 12,
+    "repos_count": 1,
+    "last_contribution": "2025-07-05T22:33:20+00:00"
+  },
+  {
+    "name": "bracesproul",
+    "reviewers_count": 12,
+    "repos_count": 1,
+    "last_contribution": "2025-04-18T18:45:37+00:00"
+  },
+  {
+    "name": "emdneto",
+    "reviewers_count": 12,
+    "repos_count": 1,
+    "last_contribution": "2025-06-23T23:54:27+00:00"
+  },
+  {
     "name": "aabmass",
     "reviewers_count": 12,
     "repos_count": 1,
     "last_contribution": "2025-06-12T14:18:19+00:00"
   },
   {
+    "name": "siriwatknp",
+    "reviewers_count": 12,
+    "repos_count": 1,
+    "last_contribution": "2025-07-01T07:50:21+00:00"
+  },
+  {
+    "name": "jcollie",
+    "reviewers_count": 12,
+    "repos_count": 1,
+    "last_contribution": "2025-07-06T00:17:29+00:00"
+  },
+  {
+    "name": "byroot",
+    "reviewers_count": 12,
+    "repos_count": 1,
+    "last_contribution": "2025-07-01T10:47:58+00:00"
+  },
+  {
+    "name": "dimitropoulos",
+    "reviewers_count": 12,
+    "repos_count": 1,
+    "last_contribution": "2025-02-13T14:42:10+00:00"
+  },
+  {
+    "name": "Janpot",
+    "reviewers_count": 12,
+    "repos_count": 1,
+    "last_contribution": "2025-07-03T08:22:30+00:00"
+  },
+  {
+    "name": "NicholasLYang",
+    "reviewers_count": 12,
+    "repos_count": 1,
+    "last_contribution": "2025-03-05T16:41:38+00:00"
+  },
+  {
     "name": "thesuperzapper",
     "reviewers_count": 12,
     "repos_count": 1,
     "last_contribution": "2025-04-07T16:04:48+00:00"
+  },
+  {
+    "name": "shaedrich",
+    "reviewers_count": 12,
+    "repos_count": 1,
+    "last_contribution": "2025-06-17T14:21:26+00:00"
+  },
+  {
+    "name": "edison1105",
+    "reviewers_count": 11,
+    "repos_count": 1,
+    "last_contribution": "2025-07-08T03:08:55+00:00"
   }
 ]

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -426,6 +426,17 @@ h1, h2, h3, h4, h5, h6 {
     margin: 0 auto;
 }
 
+/* Leaderboard hero overrides */
+.leaderboard-hero .container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.leaderboard-hero .back-link {
+    align-self: flex-start;
+}
+
 /* Filters */
 .filters {
     background: var(--bg-primary);

--- a/generate_leaderboard.py
+++ b/generate_leaderboard.py
@@ -34,6 +34,8 @@ def main():
                 ts = c.get('comment_created_at')
                 if not author or not ts:
                     continue
+                if author == 'Copilot' or '[bot]' in author:
+                    continue
                 info = users[author]
                 info['reviewers'].add(slug)
                 if repo:

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -4,8 +4,14 @@ title: Leaderboard
 description: Top contributors powering Awesome Reviewers
 ---
 
-<section class="hero">
+<section class="hero leaderboard-hero">
   <div class="container">
+    <a href="/" class="back-link">
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+        <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0z"/>
+      </svg>
+      Back to all reviewers
+    </a>
     <h1>Leaderboard</h1>
     <p>Top contributors behind the Awesome Reviewers prompts.</p>
   </div>


### PR DESCRIPTION
## Summary
- exclude `Copilot` and any `[bot]` users when generating leaderboard data
- add a back-link on the leaderboard page to return to all reviewers
- regenerate `_data/leaderboard.json` without bot accounts
- left-align the "Back to all reviewers" link on the leaderboard page

## Testing
- `python3 generate_leaderboard.py`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_b_6881d95b4e70832baa3da6ec907b14bc