### PR TITLE
Fix _reviewers allowlist

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,7 +33,7 @@ exclude:
 # Ensure discussion JSON files in the `_reviewers` directory are copied to the
 # generated site so they can be fetched by the drawer script.
 include:
-  - "_reviewers/*.json"
+  - _reviewers
 
 # Default front matter
 defaults:


### PR DESCRIPTION
# User description
## Summary
- ensure Jekyll processes the `_reviewers` directory by allowlisting the entire folder

## Testing
- `python3 generate_leaderboard.py`

------
https://chatgpt.com/codex/tasks/task_b_6881e3d22f50832bb76fa1f775ae94f4

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fixes Jekyll configuration in <code>_config.yml</code> to properly allowlist the entire <code>_reviewers</code> directory instead of just JSON files, ensuring all reviewer data is processed and available to the generated site. This change allows the drawer script to fetch reviewer information correctly.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Serve-reviewer-discuss...</td><td>July 23, 2025</td></tr>
<tr><td>nimrodkor</td><td>Fix-reviewer-reader</td><td>June 22, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/54?tool=ast>(Baz)</a>.