### PR TITLE
Fix discussion JSON fetch path

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -852,7 +852,9 @@
         const container = document.getElementById('discussion-container');
         if (!container) return;
 
-        fetch(`/reviewers/${slug}.json`)
+        // Fetch the static discussion JSON for this reviewer
+        // JSON files live in the `_reviewers` directory of the built site
+        fetch(`/_reviewers/${slug}.json`)
             .then(res => res.json())
             .then(data => {
                 container.innerHTML = data.map(renderDiscussion).join('');


### PR DESCRIPTION
# User description
## Summary
- fetch discussion JSON from `_reviewers` directory

## Testing
- `python3 -m py_compile generate_leaderboard.py migrate_json.py`


------
https://chatgpt.com/codex/tasks/task_b_6881e63f4094832bafc1526eebdb3471

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fix the discussion JSON fetch path in the default layout to correctly retrieve discussion data from the <code>_reviewers</code> directory. Updates the JavaScript fetch call to use the proper <code>/_reviewers/</code> path instead of <code>/reviewers/</code> for loading reviewer discussion JSON files.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Add-leaderboard-automa...</td><td>July 23, 2025</td></tr>
<tr><td>nimrodkor</td><td>Better-search-function...</td><td>July 10, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/55?tool=ast>(Baz)</a>.