### PR TITLE
Add discussion thread section

### DIFF
--- a/_layouts/reviewer.html
+++ b/_layouts/reviewer.html
@@ -84,6 +84,134 @@ layout: default
     </div>
 </div>
 
+<div id="discussion-thread" class="max-w-6xl mx-auto p-4 space-y-4">
+  <!-- Header inserted by JS -->
+</div>
+<script>
+  (function() {
+    const threadEl = document.getElementById('discussion-thread');
+    if (!threadEl) return; // only on full‐page
+    // Fetch JSON by slug
+    fetch(`${window.location.pathname.replace(/\/$/, '')}.json`)
+      .then(r => r.json())
+      .then(codeBlocks => renderDiscussion(threadEl, codeBlocks));
+    // Renderer function (vanilla JS + Tailwind classes)
+    function renderDiscussion(container, blocks) {
+      const totalComments = blocks.reduce((sum, b) => sum + b.comments.length, 0);
+      const participants = new Set(blocks.flatMap(b => b.comments.map(c => c.author.username))).size;
+      // 1) Header
+      container.innerHTML = `
+          <div class="flex items-center gap-2 mb-4">
+            <!-- inline MessageSquare SVG icon -->
+            <svg class="h-6 w-6 text-primary" viewBox="0 0 24 24" fill="none"
+                 stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+            </svg>
+            <h2 class="text-2xl font-bold">Discussion Thread</h2>
+            <span class="ml-auto text-xs px-2 py-1 rounded bg-muted/20 text-muted-foreground">
+              ${totalComments} Comments
+            </span>
+          </div>
+        `;
+      // 2) Blocks + Comments
+      blocks.forEach((block, i) => {
+        const blockEl = document.createElement('div');
+        blockEl.className = `rounded-lg border border-muted-foreground/20 overflow-hidden
+                               border-l-4 border-l-primary/20`;
+        // Code snippet
+        let codeHtml = `<div class="bg-slate-50 dark:bg-slate-900/50">
+            <div class="px-3 py-1.5 bg-slate-100 dark:bg-slate-800 border-b
+                        text-xs text-muted-foreground flex items-center">
+              <span class="font-mono">Changes #${i+1}</span>
+            </div>
+            <div class="font-mono text-sm">`;
+        block.changes.forEach(line => {
+          const type = line.type,
+                symbol = type==='added'?'+': type==='removed'?'-':'\u00A0',
+                colorCls = type==='added'
+                  ? 'bg-green-50 dark:bg-green-950/30 border-l-4 border-l-green-500 text-green-600 dark:text-green-400'
+                  : type==='removed'
+                  ? 'bg-red-50 dark:bg-red-950/30 border-l-4 border-l-red-500 text-red-600 dark:text-red-400'
+                  : 'hover:bg-slate-100 dark:hover:bg-slate-800 text-muted-foreground';
+          codeHtml += `
+              <div class="px-3 py-0.5 ${colorCls}">
+                <span class="select-none mr-2 text-xs">${symbol}</span>
+                <span class="break-all text-xs">${line.content||'\u00A0'}</span>
+              </div>`;
+        });
+        codeHtml += `</div></div>`;
+        blockEl.innerHTML = codeHtml;
+        // Comments
+        if (block.comments.length) {
+          const commentsWrap = document.createElement('div');
+          commentsWrap.className = 'p-4 space-y-4';
+          block.comments.forEach((c, idx) => {
+            if (idx) {
+              const sep = document.createElement('hr');
+              sep.className = 'my-3 border-t border-muted-foreground/20';
+              commentsWrap.appendChild(sep);
+            }
+            const commentEl = document.createElement('div');
+            commentEl.className = `flex gap-3 ${c.isReply?'ml-6 pl-3 border-l-2 border-muted':''}`;
+            commentEl.innerHTML = `
+                <img src="${c.author.avatar}" alt="${c.author.name}" 
+                     class="w-8 h-8 rounded-full border-2 border-background shadow-sm flex-shrink-0"/>
+                <div class="flex-1 min-w-0">
+                  <div class="flex items-center gap-2 mb-1">
+                    <h3 class="font-semibold text-sm">${c.author.name}</h3>
+                    <span class="text-xs text-muted-foreground">@${c.author.username}</span>
+                    <div class="flex items-center gap-1 text-xs text-muted-foreground ml-auto">
+                      <!-- inline Calendar SVG -->
+                      <svg class="h-3 w-3" viewBox="0 0 24 24" fill="none"
+                           stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
+                        <line x1="16" y1="2" x2="16" y2="6"/>
+                        <line x1="8" y1="2" x2="8" y2="6"/>
+                        <line x1="3" y1="10" x2="21" y2="10"/>
+                      </svg>
+                      ${c.timestamp}
+                    </div>
+                  </div>
+                  <p class="prose prose-sm max-w-none dark:prose-invert text-xs leading-relaxed m-0">
+                    ${c.content}
+                  </p>
+                </div>`;
+            commentsWrap.appendChild(commentEl);
+          });
+          blockEl.appendChild(commentsWrap);
+        }
+        container.appendChild(blockEl);
+      });
+      // 3) Summary Footer
+      const footer = document.createElement('div');
+      footer.className = `bg-slate-50 dark:bg-slate-900/50 rounded-lg p-3 
+                            text-xs text-muted-foreground flex items-center justify-between`;
+      footer.innerHTML = `
+          <div class="flex items-center gap-3">
+            <span class="flex items-center gap-1">
+              <!-- inline User SVG -->
+              <svg class="h-3 w-3" viewBox="0 0 24 24" fill="none"
+                   stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
+                <circle cx="12" cy="7" r="4"/>
+              </svg>
+              ${participants} participants
+            </span>
+            <span class="flex items-center gap-1">
+              <!-- inline MessageSquare SVG (small) -->
+              <svg class="h-3 w-3" viewBox="0 0 24 24" fill="none"
+                   stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+              </svg>
+              ${totalComments} total comments
+            </span>
+          </div>
+          <span>Last updated ${blocks[0]?.comments[0]?.timestamp||''}</span>`;
+      container.appendChild(footer);
+    }
+  })();
+</script>
+
 <script>
 
   function htmlToMarkdown(element) {


### PR DESCRIPTION
# User description
## Summary
- fetch discussion JSON data and render comment threads

## Testing
- `bundle exec jekyll build` *(fails: Liquid syntax error in existing markdown files)*

------
https://chatgpt.com/codex/tasks/task_b_6881f91e5fbc832b941986531ea6d2b9

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Adds discussion thread functionality to the <code>reviewer.html</code> layout by implementing a client-side system that fetches JSON discussion data and renders interactive comment threads. The implementation includes code block visualization, user comments with author details and timestamps, and summary statistics for enhanced code review collaboration.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Display-source-discuss...</td><td>July 23, 2025</td></tr>
<tr><td>nimrodkor</td><td>styling</td><td>July 07, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/57?tool=ast>(Baz)</a>.