### PR TITLE
Fix Liquid syntax for Jekyll in reviewer docs

### DIFF
--- a/_reviewers/airflow-explicit-over-implicit-configuration.md
+++ b/_reviewers/airflow-explicit-over-implicit-configuration.md
@@ -20,6 +20,7 @@ This practice ensures that:
 3. System behavior is easier to debug and understand
 
 For example, instead of:
+{% raw %}
 ```yaml
 # DON'T: Inferring behavior from image tag
 {{- if hasPrefix .Values.images.gitSync.tag "v3" }}
@@ -28,8 +29,10 @@ For example, instead of:
   # Use v4 configuration
 {{- end }}
 ```
+{% endraw %}
 
 Use:
+{% raw %}
 ```yaml
 # DO: Explicit configuration parameter
 gitSync:
@@ -40,5 +43,6 @@ gitSync:
   # Use v4 configuration
 {{- end }}
 ```
+{% endraw %}
 
 When adding configuration parameters that might interact with existing ones, clearly document their relationships and ensure proper handling of all cases. For instance, document when certain parameters might be ignored under specific conditions, and consider providing mechanisms to merge or append user-defined values with defaults.

--- a/_reviewers/airflow-maintain-code-consistency.md
+++ b/_reviewers/airflow-maintain-code-consistency.md
@@ -17,6 +17,7 @@ Ensure consistency throughout the codebase by following established patterns for
 
 1. Use semantic color names and variables rather than hardcoded values to maintain theme consistency and facilitate future changes:
 
+{% raw %}
 ```tsx
 // Bad
 <Button _hover={{ bg: "gray.800" }} bg="black" color="white" />
@@ -24,6 +25,7 @@ Ensure consistency throughout the codebase by following established patterns for
 // Good
 <Button _hover={{ bg: "bg.emphasized" }} bg="bg.panel" color="fg.default" />
 ```
+{% endraw %}
 
 2. Reuse existing UI components and patterns when introducing similar functionality. For example, use the same icon sets across related features to provide visual consistency:
 

--- a/_reviewers/airflow-use-proper-access-patterns.md
+++ b/_reviewers/airflow-use-proper-access-patterns.md
@@ -27,9 +27,11 @@ def my_task(**context):
 
 For version-dependent configurations, use explicit version comparison functions (like `semverCompare` in Helm) rather than hard-coding version assumptions:
 
+{% raw %}
 ```yaml
 # Good practice (Helm example)
 {{- if and (semverCompare "<3.0.0" .Values.airflowVersion) (or .Values.webserver.webserverConfig .Values.webserver.webserverConfigConfigMapName) }}
 # Version-specific configuration here
 {{- end }}
 ```
+{% endraw %}

--- a/_reviewers/appwrite-consistent-placeholder-conventions.md
+++ b/_reviewers/appwrite-consistent-placeholder-conventions.md
@@ -2,7 +2,7 @@
 title: Consistent placeholder conventions
 description: Ensure all placeholders in localization files follow consistent naming
   conventions to prevent runtime errors and text leakage in the UI. This applies to
-  both sprintf-style placeholders (`%s`) and template variables (`{{name}}`).
+  both sprintf-style placeholders (`%s`) and template variables (`{% raw %}{{name}}{% endraw %}`).
 repository: appwrite/appwrite
 label: Naming Conventions
 language: Json
@@ -10,26 +10,32 @@ comments_count: 7
 repository_stars: 51959
 ---
 
-Ensure all placeholders in localization files follow consistent naming conventions to prevent runtime errors and text leakage in the UI. This applies to both sprintf-style placeholders (`%s`) and template variables (`{{name}}`).
+Ensure all placeholders in localization files follow consistent naming conventions to prevent runtime errors and text leakage in the UI. This applies to both sprintf-style placeholders (`%s`) and template variables (`{% raw %}{{name}}{% endraw %}`).
 
 Common issues to watch for:
 1. **Correct sprintf order**: Use `%s` not `s%`
+   {% raw %}
    ```diff
    -"emails.invitation.subject": "Invitació a l'equip %s a s%",
    +"emails.invitation.subject": "Invitació a l'equip %s a %s",
    ```
+   {% endraw %}
 
 2. **Complete template variables**: Always include both opening and closing braces
+   {% raw %}
    ```diff
    -"emails.invitation.buttonText": "Accetta invito a {{team}",
    +"emails.invitation.buttonText": "Accetta invito a {{team}}",
    ```
+   {% endraw %}
    
 3. **Proper variable name boundaries**: Don't let punctuation merge with variable names
+   {% raw %}
    ```diff
    -"emails.invitation.buttonText": "Elfogadni meghívást a {{team}-re",
    +"emails.invitation.buttonText": "Elfogadni meghívást a {{team}}-re",
    ```
+   {% endraw %}
 
 Placeholder errors are particularly problematic because they can:
 - Break runtime string substitution


### PR DESCRIPTION
# User description
## Summary
- escape Liquid braces in several reviewer prompts
- wrap Helm and JSX examples in Liquid raw blocks

## Testing
- `bundle exec jekyll build` *(fails: Liquid syntax error in unrelated file)*

------
https://chatgpt.com/codex/tasks/task_b_68820b14ae50832bb7a90675800c5f32

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fixes Jekyll build errors by escaping Liquid template syntax in reviewer documentation files. Wraps code examples containing <code>{{}}</code> syntax (from Helm, JSX, and other templating languages) in <code>{% raw %}</code> blocks to prevent Jekyll from processing them as Liquid syntax during site generation.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>internal-baz-ci-app[bot]</td><td>Add-34-awesome-reviewe...</td><td>July 24, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/59?tool=ast>(Baz)</a>.