### PR TITLE
Fix drawer issues and safeguard comments data

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1609,7 +1609,7 @@ h2 .stat-value {
     transition: background-color 0.2s ease;
 }
 .leaderboard-table tr[data-contributor]:hover {
-    background: var(--bg-secondary);
+    background: var(--bg-hover, rgba(255, 255, 255, 0.1));
 }
 
 /* Discussion styles */

--- a/generate_leaderboard.py
+++ b/generate_leaderboard.py
@@ -78,7 +78,7 @@ def main():
         contributors[user] = {
             'repos': sorted(d['repos']),
             'entries': entries,
-            'comments': d['comments']
+            'comments': {k: v for k, v in d['comments'].items()}
         }
 
     data_dir = Path('_data')

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -92,7 +92,6 @@ fetch('/assets/data/contributors.json')
   .then(r => r.json())
   .then(data => {
     contributors = data;
-    attachContributorEvents();
     const hash = location.hash.slice(1);
     if (hash && contributors[hash]) {
       openContributorDrawer(hash);
@@ -101,6 +100,8 @@ fetch('/assets/data/contributors.json')
   .catch(err => {
     console.error('Failed to load contributors dataset', err);
   });
+
+attachContributorEvents();
 
 function attachContributorEvents() {
   document.querySelectorAll('tr[data-contributor]').forEach(row => {
@@ -141,7 +142,7 @@ function openContributorDrawer(user) {
 
   const stats = document.createElement('div');
   stats.className = 'contrib-stats';
-  const totalComments = Object.values(info.comments).reduce((a,b) => a + b.length, 0);
+  const totalComments = info.comments ? Object.values(info.comments).reduce((a,b) => a + b.length, 0) : 0;
   stats.innerHTML = `
     <div class="contrib-stat"><span class="contrib-stat-value">${info.repos.length}</span>Repos</div>
     <div class="contrib-stat"><span class="contrib-stat-value">${info.entries.length}</span>Entries</div>
@@ -190,25 +191,33 @@ function openContributorDrawer(user) {
   entriesDetails.appendChild(entriesList);
   content.appendChild(entriesDetails);
 
-  const commentsDetails = createSection('Comments', Object.keys(info.comments).length);
-  Object.keys(info.comments).forEach(slug => {
-    const group = document.createElement('details');
-    const sum = document.createElement('summary');
-    sum.textContent = `${slug} (${info.comments[slug].length})`;
-    group.appendChild(sum);
-    const list = document.createElement('ul');
-    info.comments[slug].forEach(text => {
-      const li = document.createElement('li');
-      li.textContent = text;
-      list.appendChild(li);
+  const commentsDetails = createSection('Comments', info.comments ? Object.keys(info.comments).length : 0);
+  if (info.comments) {
+    Object.keys(info.comments).forEach(slug => {
+      const group = document.createElement('details');
+      const sum = document.createElement('summary');
+      sum.textContent = `${slug} (${info.comments[slug].length})`;
+      group.appendChild(sum);
+      const list = document.createElement('ul');
+      info.comments[slug].forEach(text => {
+        const li = document.createElement('li');
+        li.textContent = text;
+        list.appendChild(li);
+      });
+      group.appendChild(list);
+      commentsDetails.appendChild(group);
     });
-    group.appendChild(list);
-    commentsDetails.appendChild(group);
-  });
+  }
   content.appendChild(commentsDetails);
 
   drawer.classList.add('open');
   history.replaceState(null, '', `#${user}`);
+}
+
+function closeDrawer() {
+  const drawer = document.getElementById('drawer');
+  drawer.classList.remove('open');
+  history.replaceState(null, '', location.pathname);
 }
 
 window.addEventListener('hashchange', () => {


### PR DESCRIPTION
## Summary
- ensure contributor events attach even if fetch fails
- check for missing comments data before iterating
- add missing `closeDrawer` implementation
- improve contributor row hover style
- serialize contributors' comments to regular `dict`

## Testing
- `python3 -m py_compile generate_leaderboard.py`


------
https://chatgpt.com/codex/tasks/task_b_688213dea94c832b9b72fb668b8c5e7e