### PR TITLE
Add dynamic GitHub metadata

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1816,3 +1816,24 @@ h2 .stat-value {
     white-space: pre-wrap;
     font-size: 0.875rem;
 }
+
+/* Contributor profile meta */
+.profile-meta {
+    list-style: none;
+    padding: 0;
+    margin: 0.5rem 0 0;
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+}
+.profile-meta li + li {
+    margin-top: 0.25rem;
+}
+.verified-badge {
+    color: var(--accent);
+    margin-left: 0.25rem;
+}
+a[target="_blank"]::after {
+    content: "\2197"; /* ↗ */
+    font-size: 0.75em;
+    margin-left: 0.25em;
+}

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -148,8 +148,74 @@ function openContributorDrawer(user) {
     <div class="contrib-stat"><span class="contrib-stat-value">${totalComments}</span>Comments</div>
   `;
   infoBox.appendChild(stats);
+
+  const metaList = document.createElement('ul');
+  metaList.className = 'profile-meta';
+  infoBox.appendChild(metaList);
   header.appendChild(infoBox);
   content.appendChild(header);
+
+  fetch(`https://api.github.com/users/${user}`)
+    .then(r => r.ok ? r.json() : null)
+    .then(async data => {
+      if (!data) return;
+      if (data.site_admin) {
+        const badge = document.createElement('span');
+        badge.className = 'verified-badge';
+        badge.textContent = '✓';
+        nameEl.appendChild(badge);
+
+        const row = document.querySelector(`tr[data-contributor="${user}"] td:nth-child(2)`);
+        if (row && !row.querySelector('.verified-badge')) {
+          const badgeClone = badge.cloneNode(true);
+          row.appendChild(badgeClone);
+        }
+      }
+      const items = [];
+      if (typeof data.followers === 'number' && typeof data.following === 'number') {
+        const fmt = n => n >= 1000 ? (n/1000).toFixed(1).replace(/\.0$/, '') + 'k' : n;
+        items.push(`${fmt(data.followers)} followers \u2022 ${fmt(data.following)} following`);
+      }
+      if (data.location) {
+        try {
+          if (!window._tzList) {
+            const l = await fetch('https://worldtimeapi.org/api/timezone');
+            window._tzList = l.ok ? await l.json() : null;
+          }
+          if (window._tzList) {
+            const zone = window._tzList.find(z => z.toLowerCase().includes(data.location.toLowerCase()));
+            if (zone) {
+              const tzRes = await fetch(`https://worldtimeapi.org/api/timezone/${encodeURIComponent(zone)}`);
+              if (tzRes.ok) {
+                const tz = await tzRes.json();
+                const dt = new Date(tz.datetime);
+                const time = dt.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'});
+                const offset = tz.utc_offset.replace(':00','');
+                items.push(`${data.location.split(',')[0]} \u2013 ${time} (GMT${offset})`);
+              }
+            }
+          }
+        } catch (e) {}
+      }
+      if (data.email) items.push(`<a href="mailto:${data.email}">${data.email}</a>`);
+      if (data.blog) {
+        let txt = data.blog.replace(/https?:\/\//,'').replace(/\/?$/,'');
+        items.push(`<a href="${data.blog}" target="_blank" rel="noopener noreferrer">${txt}</a>`);
+      }
+      if (data.twitter_username) {
+        const handle = '@' + data.twitter_username;
+        items.push(`<a href="https://twitter.com/${data.twitter_username}" target="_blank" rel="noopener noreferrer">${handle}</a>`);
+      }
+      if (data.blog && /linkedin\.com\/in\//i.test(data.blog)) {
+        items.push(`<a href="${data.blog}" target="_blank" rel="noopener noreferrer">LinkedIn</a>`);
+      }
+      items.forEach(html => {
+        const li = document.createElement('li');
+        li.innerHTML = html;
+        metaList.appendChild(li);
+      });
+    })
+    .catch(() => {});
 
   function createSection(title, count) {
     const details = document.createElement('details');


### PR DESCRIPTION
## Summary
- fetch GitHub metadata when opening contributor drawer
- display verification badge and profile meta info
- show external link arrow icons via CSS

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_6882188e195c832ba7dcfa43154a507f