### PR TITLE
Fix share links to open full reviewer pages

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -822,7 +822,7 @@
     }
 
     async function copyDeeplink(slug, button) {
-        const url = `${window.location.origin}${window.location.pathname}#${slug}`;
+        const url = `${window.location.origin}/reviewers/${slug}/`;
 
         try {
             if (navigator.clipboard && navigator.clipboard.writeText) {
@@ -908,8 +908,14 @@
     }
 
     function shareFromDrawer(e) {
-        const slug = location.hash.slice(1);
-        copyDeeplink(slug, e.currentTarget);
+        let slug = location.hash.slice(1);
+        if (!slug) {
+            const parts = window.location.pathname.split('/').filter(Boolean);
+            slug = parts[parts.length - 1];
+        }
+        if (slug) {
+            copyDeeplink(slug, e.currentTarget);
+        }
     }
 
     function loadMore() {

--- a/_layouts/reviewer.html
+++ b/_layouts/reviewer.html
@@ -178,9 +178,13 @@ layout: default
   }
 
   async function shareFromDrawer(e) {
-    const slug = location.hash.slice(1);
+    let slug = location.hash.slice(1);
+    if (!slug) {
+      const parts = window.location.pathname.split('/').filter(Boolean);
+      slug = parts[parts.length - 1];
+    }
     const button = e.currentTarget;
-    const url = `${window.location.origin}${window.location.pathname}#${slug}`;
+    const url = `${window.location.origin}/reviewers/${slug}/`;
 
     try {
       if (navigator.clipboard && navigator.clipboard.writeText) {


### PR DESCRIPTION
# User description
## Summary
- fix share link generation to point to `/reviewers/<slug>/`
- handle missing hash in `shareFromDrawer`

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_68821a569a2c832b9e90c5241a4e7c16

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fix share link generation in <code>copyDeeplink</code> and <code>shareFromDrawer</code> functions to create proper reviewer page URLs instead of hash-based fragments. Handle missing hash scenarios by extracting reviewer slugs from the pathname to ensure robust sharing functionality across reviewer pages.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>refactor-discussions-u...</td><td>July 24, 2025</td></tr>
<tr><td>nimrodkor</td><td>Better-search-function...</td><td>July 10, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/63?tool=ast>(Baz)</a>.