### PR TITLE
Improve leaderboard comment styling

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1779,6 +1779,10 @@ h2 .stat-value {
     text-decoration: underline;
 }
 
+.contrib-section .chat-thread {
+    padding: 0.5rem 1rem 1rem;
+}
+
 .chat-thread {
     display: flex;
     flex-direction: column;

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -198,13 +198,21 @@ function openContributorDrawer(user) {
       const sum = document.createElement('summary');
       sum.textContent = `${slug} (${info.comments[slug].length})`;
       group.appendChild(sum);
-      const list = document.createElement('ul');
+      const thread = document.createElement('div');
+      thread.className = 'chat-thread';
       info.comments[slug].forEach(text => {
-        const li = document.createElement('li');
-        li.textContent = text;
-        list.appendChild(li);
+        const msg = document.createElement('div');
+        msg.className = 'chat-message';
+        const bubble = document.createElement('div');
+        bubble.className = 'chat-bubble';
+        const body = document.createElement('div');
+        body.className = 'chat-body';
+        body.innerHTML = escapeHtml(text).replace(/\n/g, '<br>');
+        bubble.appendChild(body);
+        msg.appendChild(bubble);
+        thread.appendChild(msg);
       });
-      group.appendChild(list);
+      group.appendChild(thread);
       commentsDetails.appendChild(group);
     });
   }


### PR DESCRIPTION
## Summary
- style leaderboard comments using chat thread layout
- pad comment threads in contributor drawer for readability

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_6882209d6390832bbf54c76730a75c12