### PR TITLE
Add contributor details to leaderboard

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1612,6 +1612,28 @@ h2 .stat-value {
     background: var(--bg-hover, rgba(255, 255, 255, 0.1));
 }
 
+.leaderboard-table .loc-cell,
+.leaderboard-table .company-cell,
+.leaderboard-table .links-cell {
+    white-space: nowrap;
+}
+
+.leaderboard-table .meta-icon {
+    width: 12px;
+    height: 12px;
+    vertical-align: text-bottom;
+    margin-right: 0.25rem;
+}
+
+.leaderboard-table .links-cell a {
+    margin-right: 0.25rem;
+    color: var(--text-secondary);
+}
+
+.leaderboard-table .links-cell a:hover {
+    color: var(--text-primary);
+}
+
 /* Discussion styles */
 .discussions-section {
     padding: 1.5rem;

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -33,19 +33,25 @@ description: Top contributors powering Awesome Reviewers
           <th>Reviewers</th>
           <th>Repositories</th>
           <th>Last Contribution</th>
+          <th>Location</th>
+          <th>Company</th>
+          <th>Links</th>
         </tr>
       </thead>
       <tbody>
         {% for user in site.data.leaderboard %}
         <tr data-contributor="{{ user.name }}">
           <td>{{ forloop.index }}</td>
-          <td>
+          <td class="lb-name">
             {% if forloop.index == 1 %}🥇 {% elsif forloop.index == 2 %}🥈 {% elsif forloop.index == 3 %}🥉 {% endif %}
             <a href="https://github.com/{{ user.name }}" target="_blank" rel="noopener noreferrer">{{ user.name }}</a>
           </td>
           <td data-sort="{{ user.reviewers_count }}">{{ user.reviewers_count }}</td>
           <td data-sort="{{ user.repos_count }}">{{ user.repos_count }}</td>
           <td data-sort="{{ user.last_contribution }}">{{ user.last_contribution | date: '%Y-%m-%d' }}</td>
+          <td class="loc-cell"></td>
+          <td class="company-cell"></td>
+          <td class="links-cell"></td>
         </tr>
         {% endfor %}
       </tbody>
@@ -96,6 +102,7 @@ fetch('/assets/data/contributors.json')
     if (hash && contributors[hash]) {
       openContributorDrawer(hash);
     }
+    loadProfileData();
   })
   .catch(err => {
     console.error('Failed to load contributors dataset', err);
@@ -110,6 +117,42 @@ function attachContributorEvents() {
       const user = row.dataset.contributor;
       openContributorDrawer(user);
     });
+  });
+}
+
+function loadProfileData() {
+  document.querySelectorAll('tr[data-contributor]').forEach(row => {
+    const user = row.dataset.contributor;
+    fetch(`https://api.github.com/users/${user}`)
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        if (!data) return;
+        const locCell = row.querySelector('.loc-cell');
+        const compCell = row.querySelector('.company-cell');
+        const linksCell = row.querySelector('.links-cell');
+        if (data.location && locCell) {
+          locCell.dataset.sort = data.location;
+          locCell.innerHTML = `<svg class="meta-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"/><circle cx="12" cy="10" r="3"/></svg> ${data.location}`;
+        }
+        if (data.company && compCell) {
+          compCell.dataset.sort = data.company;
+          compCell.innerHTML = `<svg class="meta-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="7" width="20" height="14" rx="2" ry="2"/><path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/></svg> ${data.company}`;
+        }
+        if (linksCell) {
+          const links = [];
+          if (data.blog) {
+            links.push(`<a href="${data.blog}" target="_blank" rel="noopener noreferrer" title="Website"><svg class="meta-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg></a>`);
+          }
+          if (data.twitter_username) {
+            links.push(`<a href="https://twitter.com/${data.twitter_username}" target="_blank" rel="noopener noreferrer" title="Twitter"><svg class="meta-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M23 3a10.9 10.9 0 0 1-3.14 1.53 4.48 4.48 0 0 0-7.86 3v1A10.66 10.66 0 0 1 3 4s-4 9 5 13a11.64 11.64 0 0 1-7 2c9 5 20 0 20-11.5a4.5 4.5 0 0 0-.08-.83A7.72 7.72 0 0 0 23 3z"/></svg></a>`);
+          }
+          if (data.email) {
+            links.push(`<a href="mailto:${data.email}" title="Email"><svg class="meta-icon" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg></a>`);
+          }
+          linksCell.innerHTML = links.join(' ');
+        }
+      })
+      .catch(() => {});
   });
 }
 
@@ -233,7 +276,7 @@ function openContributorDrawer(user) {
   info.repos.forEach(r => {
     const li = document.createElement('li');
     const a = document.createElement('a');
-    a.href = `/?repo=${encodeURIComponent(r)}`;
+    a.href = `/?repos=${encodeURIComponent(r)}`;
     a.target = '_blank';
     a.rel = 'noopener noreferrer';
     a.textContent = r;


### PR DESCRIPTION
## Summary
- show location, company and profile links in the leaderboard
- load GitHub profile data for leaderboard rows
- add supporting styles
- fix repository filter link in contributor drawer

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_6882245a1e40832b84490cefae6f258f