### PR TITLE
Improve header responsiveness

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -90,6 +90,14 @@
                          style="display: none;">
                 </div>
             </a>
+            <button class="menu-toggle" aria-label="Toggle navigation">
+                <svg class="hamburger-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+                    <path d="M3 6h18M3 12h18M3 18h18"/>
+                </svg>
+                <svg class="close-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" style="display: none;">
+                    <path d="M6 6l12 12M6 18L18 6"/>
+                </svg>
+            </button>
             <div class="cta-group">
                 <div class="header-links">
                     <a href="https://baz.co/resources/from-review-thread-to-team-standard-how-we-built-awesomereviewers" class="header-link secondary" target="_blank"

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -251,6 +251,21 @@ h1, h2, h3, h4, h5, h6 {
     object-fit: contain;
 }
 
+.menu-toggle {
+    display: none;
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--text-primary);
+    grid-column: 3;
+    justify-self: end;
+}
+
+.menu-toggle svg {
+    width: 20px;
+    height: 20px;
+}
+
 .header-actions {
     display: flex;
     align-items: center;
@@ -1257,20 +1272,32 @@ h2 .stat-value {
 /* Responsive */
 @media (max-width: 768px) {
     .header-content {
-        flex-direction: column;
-        gap: 1rem;
+        grid-template-columns: auto 1fr auto;
+        gap: 0.5rem;
+    }
+
+    .menu-toggle {
+        display: block;
     }
 
     .cta-group {
+        display: none;
         flex-direction: column;
-        gap: 1rem;
+        gap: 0.75rem;
         width: 100%;
+        background: var(--bg-card);
+        border-bottom: 1px solid var(--border);
+        padding: 0.5rem 0;
+    }
+
+    .header.open .cta-group {
+        display: flex;
     }
 
     .header-links {
         gap: 0.5rem;
-        flex-wrap: wrap;
-        justify-content: center;
+        flex-direction: column;
+        align-items: flex-start;
     }
 
     .header-link {
@@ -1423,10 +1450,30 @@ h2 .stat-value {
 
     .header-content {
         padding: 0.5rem 0;
+        grid-template-columns: auto 1fr auto;
+    }
+
+    .menu-toggle {
+        display: block;
+    }
+
+    .cta-group {
+        display: none;
+        flex-direction: column;
+        gap: 0.5rem;
+        width: 100%;
+        background: var(--bg-card);
+        border-bottom: 1px solid var(--border);
+        padding: 0.5rem 0;
+    }
+
+    .header.open .cta-group {
+        display: flex;
     }
 
     .header-links {
-        flex-wrap: wrap;
+        flex-direction: column;
+        align-items: flex-start;
         gap: 0.25rem;
     }
 
@@ -1547,6 +1594,24 @@ h2 .stat-value {
 
     .reviewer-meta {
         margin-top: 0.5rem;
+    }
+
+    .menu-toggle {
+        display: block;
+    }
+
+    .cta-group {
+        display: none;
+        flex-direction: column;
+        gap: 0.5rem;
+        width: 100%;
+        background: var(--bg-card);
+        border-bottom: 1px solid var(--border);
+        padding: 0.5rem 0;
+    }
+
+    .header.open .cta-group {
+        display: flex;
     }
 
     .tag {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -101,3 +101,15 @@ form && form.addEventListener('submit', async e => {
     submitBtn.textContent = originalButtonText;
   }
 });
+
+// Mobile header menu toggle
+const menuToggle = document.querySelector('.menu-toggle');
+const headerEl = document.querySelector('.header');
+if (menuToggle && headerEl) {
+  menuToggle.addEventListener('click', () => {
+    headerEl.classList.toggle('open');
+    const open = headerEl.classList.contains('open');
+    menuToggle.querySelector('.hamburger-icon').style.display = open ? 'none' : 'block';
+    menuToggle.querySelector('.close-icon').style.display = open ? 'block' : 'none';
+  });
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -109,7 +109,9 @@ if (menuToggle && headerEl) {
   menuToggle.addEventListener('click', () => {
     headerEl.classList.toggle('open');
     const open = headerEl.classList.contains('open');
-    menuToggle.querySelector('.hamburger-icon').style.display = open ? 'none' : 'block';
-    menuToggle.querySelector('.close-icon').style.display = open ? 'block' : 'none';
+    const hamburgerIcon = menuToggle.querySelector('.hamburger-icon');
+    const closeIcon = menuToggle.querySelector('.close-icon');
+    if (hamburgerIcon) hamburgerIcon.style.display = open ? 'none' : 'block';
+    if (closeIcon) closeIcon.style.display = open ? 'block' : 'none';
   });
 }


### PR DESCRIPTION
# User description
## Summary
- add hamburger toggle button to header
- show/hide navigation links on smaller screens
- implement mobile menu logic in JavaScript
- style mobile menu and toggle

## Testing
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_b_688229a5a1bc832bb690c61bde9e73b6

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Implements mobile-responsive header navigation by adding a hamburger menu toggle system that shows/hides navigation links on smaller screens. Modifies the header layout to use CSS Grid, adds JavaScript toggle functionality for menu state management, and introduces a hamburger button with SVG icons to the HTML structure.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Add-contributor-detail...</td><td>July 24, 2025</td></tr>
<tr><td>nimrodkor</td><td>Better-search-function...</td><td>July 10, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/68?tool=ast>(Baz)</a>.