### PR TITLE
Add research article and footer nav

### DIFF
--- a/_includes/quote-block.html
+++ b/_includes/quote-block.html
@@ -1,0 +1,3 @@
+<blockquote class="max-w-3xl mx-auto italic border-l-4 border-indigo-500 pl-4 text-gray-800 text-lg leading-relaxed mb-16">
+  “This quote highlights a key insight into how engineering teams perceive code reviews as both a technical and cultural practice.”
+</blockquote>

--- a/_includes/stats-card.html
+++ b/_includes/stats-card.html
@@ -1,0 +1,14 @@
+<section class="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-5xl mx-auto mb-16">
+  <div class="bg-white rounded-xl shadow-sm p-6 border border-gray-200">
+    <h3 class="text-xl font-medium text-gray-800 mb-2">Avg Review Time</h3>
+    <p class="text-3xl font-bold text-indigo-600">4.2h</p>
+  </div>
+  <div class="bg-white rounded-xl shadow-sm p-6 border border-gray-200">
+    <h3 class="text-xl font-medium text-gray-800 mb-2">Comments / PR</h3>
+    <p class="text-3xl font-bold text-indigo-600">6.7</p>
+  </div>
+  <div class="bg-white rounded-xl shadow-sm p-6 border border-gray-200">
+    <h3 class="text-xl font-medium text-gray-800 mb-2">Approval Rate</h3>
+    <p class="text-3xl font-bold text-indigo-600">82%</p>
+  </div>
+</section>

--- a/_includes/trend-section.html
+++ b/_includes/trend-section.html
@@ -1,0 +1,6 @@
+<section class="max-w-4xl mx-auto mb-16">
+  <h2 class="text-3xl font-semibold text-gray-900 mb-4">Trend Section</h2>
+  <p class="text-gray-700 text-lg leading-relaxed">
+    An overview of how code review dynamics are shifting across engineering teams. Include high-level summaries or charts here.
+  </p>
+</section>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -103,6 +103,7 @@
                     <a href="https://baz.co/resources/from-review-thread-to-team-standard-how-we-built-awesomereviewers" class="header-link secondary" target="_blank"
                        rel="noopener noreferrer" aria-label="Learn more about how we built Awesome Reviewers">Blog post</a>
                     <a href="/leaderboard" class="header-link secondary" aria-label="View contributor leaderboard">Leaderboard</a>
+                    <a href="/research/" class="header-link secondary" aria-label="Research articles">Research</a>
                     <a href="https://docs.baz.co/basics/model-context-protocol-mcp" class="header-link discovery"
                        target="_blank" rel="noopener noreferrer" aria-label="Learn about Model Context Protocol (MCP)">MCP</a>
                     <a href="https://baz.co/agents" class="header-link primary" target="_blank"
@@ -129,6 +130,13 @@
 
 <footer class="footer">
     <div class="container">
+        <nav class="footer-links">
+            <a href="https://baz.co/resources/from-review-thread-to-team-standard-how-we-built-awesomereviewers" target="_blank" rel="noopener noreferrer">Blog post</a>
+            <a href="/leaderboard">Leaderboard</a>
+            <a href="/research/">Research</a>
+            <a href="https://docs.baz.co/basics/model-context-protocol-mcp" target="_blank" rel="noopener noreferrer">MCP</a>
+            <a href="https://baz.co/agents" target="_blank" rel="noopener noreferrer">Deploy agents</a>
+        </nav>
         <p>&copy; <span id="current-year"> </span> Baz Technologies. Ready-to-use system prompts for better code reviews.</p>
     </div>
 </footer>

--- a/research/index.md
+++ b/research/index.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Code Review Trends
+---
+
+{% include trend-section.html %}
+{% include stats-card.html %}
+{% include quote-block.html %}


### PR DESCRIPTION
## Summary
- add Jekyll includes for trend, stats and quote blocks
- create `research` article page using the new includes
- add Research link to the header
- mirror all header links in the footer for navigation

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_688602557d4c832bb89eda3ead6d588e