### PR TITLE
Add pagination to show top 10 reviewers

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@ layout: default
             {% for reviewer in sorted_reviewers %}
             {% assign index = forloop.index0 %}
             {% assign slug = reviewer.url | remove: '/reviewers/' | remove: '/' %}
-            <div class="reviewer-card{% if index >= 100 %} extra-reviewer{% endif %}" id="{{ slug }}" data-slug="{{ slug }}"
+            <div class="reviewer-card{% if index >= 10 %} extra-reviewer{% endif %}" id="{{ slug }}" data-slug="{{ slug }}"
                  data-repo="{{ reviewer.repository }}"
                  data-category="{{ reviewer.label }}"
                  data-language="{{ reviewer.language }}">
@@ -85,6 +85,11 @@ layout: default
             </div>
             {% endfor %}
         </div>
+        {% if site.reviewers.size > 10 %}
+        <div class="load-more-wrapper">
+            <button id="load-more" onclick="loadMore()">Show all Reviewers</button>
+        </div>
+        {% endif %}
     </div>
 </main>
 


### PR DESCRIPTION
## Summary
- only show the first 10 reviewers on the home page
- add **Show all Reviewers** button to reveal the rest

## Testing
- `bundle exec jekyll build` *(fails: Liquid warnings and missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_6886062964cc832b9656ea9a26ffa68f