### PR TITLE
Add contributor avatars to leaderboard

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1651,6 +1651,15 @@ h2 .stat-value {
     margin-right: 0.5rem;
 }
 
+/* Avatar displayed in the leaderboard table */
+.lb-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    margin-right: 0.5rem;
+    vertical-align: middle;
+}
+
 /* Leaderboard table styles */
 .leaderboard-table {
     width: 100%;

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -44,6 +44,7 @@ description: Top contributors powering Awesome Reviewers
           <td>{{ forloop.index }}</td>
           <td class="lb-name">
             {% if forloop.index == 1 %}🥇 {% elsif forloop.index == 2 %}🥈 {% elsif forloop.index == 3 %}🥉 {% endif %}
+            <img class="lb-avatar" src="https://github.com/{{ user.name }}.png?size=40" alt="{{ user.name }} avatar">
             <a href="https://github.com/{{ user.name }}" target="_blank" rel="noopener noreferrer">{{ user.name }}</a>
           </td>
           <td data-sort="{{ user.reviewers_count }}">{{ user.reviewers_count }}</td>


### PR DESCRIPTION
# User description
## Summary
- show contributor avatars in leaderboard
- style leaderboard avatars

## Testing
- `python generate_leaderboard.py`
- `bundle install`
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_b_688606d5b7e4832bb6ed0a0881084b52

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhance the leaderboard by adding GitHub profile avatars next to contributor names, fetching images from GitHub's API and styling them as circular 32px images. The changes modify the leaderboard HTML template to include avatar images and add corresponding CSS styling through the <code>.lb-avatar</code> class.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Improve-header-respons...</td><td>July 24, 2025</td></tr>
<tr><td>nimrodkor</td><td>Spacing</td><td>July 09, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/76?tool=ast>(Baz)</a>.