### PR TITLE
Fix pagination of reviewer cards

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -426,6 +426,11 @@
 
         const cards = document.querySelectorAll('.reviewer-card');
         let visibleCount = 0;
+        const initialView =
+            searchTerm === '' &&
+            selectedCategories.length === 0 &&
+            selectedRepos.length === 0 &&
+            selectedLanguages.length === 0;
 
         cards.forEach(card => {
             const titleEl = card.querySelector('.reviewer-title');
@@ -449,8 +454,16 @@
             const matchesLanguage = selectedLanguages.length === 0 || selectedLanguages.includes(language);
 
             if (matchesSearch && matchesCategory && matchesRepo && matchesLanguage) {
-                card.style.display = 'block';
-                visibleCount++;
+                if (
+                    initialView &&
+                    card.classList.contains('extra-reviewer') &&
+                    document.getElementById('load-more')
+                ) {
+                    card.style.display = 'none';
+                } else {
+                    card.style.display = 'block';
+                    visibleCount++;
+                }
             } else {
                 card.style.display = 'none';
             }

--- a/index.html
+++ b/index.html
@@ -40,10 +40,11 @@ layout: default
     <div class="container">
         <div class="reviewer-grid">
             {% assign sorted_reviewers = site.reviewers | sort: "comments_count" | reverse %}
+            {% assign initial_limit = 100 %}
             {% for reviewer in sorted_reviewers %}
             {% assign index = forloop.index0 %}
             {% assign slug = reviewer.url | remove: '/reviewers/' | remove: '/' %}
-            <div class="reviewer-card{% if index >= 10 %} extra-reviewer{% endif %}" id="{{ slug }}" data-slug="{{ slug }}"
+            <div class="reviewer-card{% if index >= initial_limit %} extra-reviewer{% endif %}" id="{{ slug }}" data-slug="{{ slug }}"
                  data-repo="{{ reviewer.repository }}"
                  data-category="{{ reviewer.label }}"
                  data-language="{{ reviewer.language }}">
@@ -85,7 +86,7 @@ layout: default
             </div>
             {% endfor %}
         </div>
-        {% if site.reviewers.size > 10 %}
+        {% if site.reviewers.size > 100 %}
         <div class="load-more-wrapper">
             <button id="load-more" onclick="loadMore()">Show all Reviewers</button>
         </div>


### PR DESCRIPTION
# User description
## Summary
- only show first 100 reviewers by default
- keep extra cards hidden during filtering unless "Show all" is clicked

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_68861ed6dc70832ba5152e274dacd874

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Increases the default display limit for reviewer cards from 10 to 100 and fixes filtering behavior to keep extra cards hidden during search/filtering unless "Show all" is explicitly clicked. Modifies the reviewer grid rendering logic in <code>index.html</code> and the filtering function in <code>_layouts/default.html</code> to properly handle pagination state during user interactions.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Update-layout-with-foo...</td><td>July 27, 2025</td></tr>
<tr><td>nimrodkor</td><td>Better-search-function...</td><td>July 10, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/78?tool=ast>(Baz)</a>.