### PR TITLE
Fix theme selector alignment

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -347,10 +347,12 @@ h1, h2, h3, h4, h5, h6 {
     fill: currentColor;
 }
 
+
 .theme-switch-container {
     display: flex;
-    justify-content: flex-start;
-    grid-column: 1;
+    justify-content: flex-end;
+    margin-left: auto;
+    grid-column: 3;
 }
 
 .footer-links .theme-switch-container {


### PR DESCRIPTION
# User description
## Summary
- align the theme switch controls to the right

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_688622619abc832bbe2d1ddee945f5eb

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Repositions the theme switch container to align to the right side by updating CSS flexbox and grid properties. Modifies the <code>.theme-switch-container</code> styling to use right-aligned justification and moves it to the third grid column.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Add-contributor-avatar...</td><td>July 27, 2025</td></tr>
<tr><td>nimrodkor</td><td>Spacing</td><td>July 09, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/80?tool=ast>(Baz)</a>.