### PR TITLE
Fix GitHub profile fetch for leaderboard

### DIFF
--- a/leaderboard.html
+++ b/leaderboard.html
@@ -131,7 +131,12 @@ function loadProfileData() {
       return;
     }
     setTimeout(() => {
-      fetch(`https://api.github.com/users/${user}`)
+      fetch(`https://api.github.com/users/${user}`, {
+        headers: {
+          'Accept': 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28'
+        }
+      })
         .then(r => (r.ok ? r.json() : null))
         .then(data => {
           if (!data) return;
@@ -214,7 +219,12 @@ function openContributorDrawer(user) {
   content.appendChild(header);
 
   const existing = info.profile;
-  const load = existing ? Promise.resolve(existing) : fetch(`https://api.github.com/users/${user}`).then(r => r.ok ? r.json() : null);
+  const load = existing ? Promise.resolve(existing) : fetch(`https://api.github.com/users/${user}`, {
+    headers: {
+      'Accept': 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28'
+    }
+  }).then(r => r.ok ? r.json() : null);
   load.then(async data => {
       if (!data) return;
       if (!existing) info.profile = data;


### PR DESCRIPTION
# User description
## Summary
- include required API headers when fetching user profiles

## Testing
- `bundle install` *(fails: command not found or permission issue)*

------
https://chatgpt.com/codex/tasks/task_b_6886297424b0832bbcdf41ac9cf0e8dd

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Adds required API headers to GitHub profile fetch requests in the leaderboard functionality. The changes ensure proper communication with GitHub's API by including the <code>Accept</code> and <code>X-GitHub-Api-Version</code> headers in both profile loading scenarios within <code>leaderboard.html</code>.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Add-map-view-to-leader...</td><td>July 27, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/84?tool=ast>(Baz)</a>.