### PR TITLE
Fix reviewer count display

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -475,17 +475,26 @@
         });
 
         // Update the reviewer count
-        updateReviewerCount(visibleCount);
+        updateReviewerCount(
+            visibleCount,
+            initialView && document.getElementById('load-more')
+                ? cards.length
+                : null
+        );
         
         // Update URL parameters
         updateUrlParams();
     }
 
-    function updateReviewerCount(count) {
+    function updateReviewerCount(visible, total) {
         const counterElement = document.getElementById('reviewer-count');
         if (counterElement) {
-            counterElement.dataset.count = count;
-            counterElement.textContent = count.toLocaleString();
+            counterElement.dataset.count = visible;
+            const totalVal =
+                typeof total === 'number' && total > visible ? total : null;
+            const parts = [visible.toLocaleString()];
+            if (totalVal) parts.push('of', totalVal.toLocaleString());
+            counterElement.textContent = parts.join(' ');
         }
     }
 
@@ -577,8 +586,15 @@
             loadFiltersFromUrl();
 
             // Format initial reviewer count and apply filters
-            const initialCount = document.querySelectorAll('.reviewer-card').length;
-            updateReviewerCount(initialCount);
+            const allCards = document.querySelectorAll('.reviewer-card');
+            const totalCount = allCards.length;
+            const visibleCount = Array.from(allCards).filter(
+                c => !c.classList.contains('extra-reviewer')
+            ).length;
+            updateReviewerCount(
+                visibleCount,
+                document.getElementById('load-more') ? totalCount : null
+            );
             filterReviewers();
 
             document.querySelectorAll('.reviewer-card').forEach(card => {

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ layout: default
 
 <section class="library-header">
     <div class="container">
-        <h2>Reviewers Library (<span id="reviewer-count" class="stat-value" data-count="{{ site.reviewers.size }}">{{ site.reviewers.size }}</span>)</h2>
+        <h2>Reviewers Library (<span id="reviewer-count" class="stat-value" data-total="{{ site.reviewers.size }}">{{ site.reviewers.size }}</span>)</h2>
         <button id="add-repo-button" class="add-repo-btn">Add Repository</button>
     </div>
 </section>


### PR DESCRIPTION
# User description
## Summary
- show both the visible count and total reviewer count before the list is expanded

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_68862bf1f6f8832b9e63adf2cc256948

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhances the reviewer count display to show both visible and total reviewer counts in the format "X of Y" when there are additional reviewers available beyond the initially displayed ones. Updates the <code>updateReviewerCount</code> function to accept both visible and total parameters and modifies the initialization logic to properly detect and display the expanded count format.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Add-map-view-to-leader...</td><td>July 27, 2025</td></tr>
<tr><td>nimrodkor</td><td>Better-search-function...</td><td>July 10, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/85?tool=ast>(Baz)</a>.