### PR TITLE
Add reviewer download option

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -948,7 +948,8 @@
     }
 
     function downloadReviewer(slug) {
-        fetch(`/_reviewers/${slug}.md`)
+        const url = `https://raw.githubusercontent.com/baz-scm/awesome-reviewers/main/_reviewers/${slug}.md`;
+        fetch(url)
             .then(res => {
                 if (!res.ok) throw new Error('Fetch failed');
                 return res.text();

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -947,6 +947,40 @@
         }
     }
 
+    function downloadReviewer(slug) {
+        fetch(`/_reviewers/${slug}.md`)
+            .then(res => {
+                if (!res.ok) throw new Error('Fetch failed');
+                return res.text();
+            })
+            .then(text => {
+                const blob = new Blob([text], { type: 'text/markdown' });
+                const link = document.createElement('a');
+                link.href = URL.createObjectURL(blob);
+                link.download = `${slug}.agents.md`;
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+            })
+            .catch(err => console.error('Download failed', err));
+    }
+
+    function downloadFromCard(e, slug) {
+        e.stopPropagation();
+        downloadReviewer(slug);
+    }
+
+    function downloadFromDrawer(e) {
+        let slug = location.hash.slice(1);
+        if (!slug) {
+            const parts = window.location.pathname.split('/').filter(Boolean);
+            slug = parts[parts.length - 1];
+        }
+        if (slug) {
+            downloadReviewer(slug);
+        }
+    }
+
     function loadMore() {
         document.querySelectorAll('.extra-reviewer').forEach(card => {
             card.style.display = 'block';

--- a/_layouts/reviewer.html
+++ b/_layouts/reviewer.html
@@ -57,7 +57,7 @@ layout: default
                     <span id="copy-text">Copy Prompt</span>
                 </button>
                 <button class="share-button copy-button" onclick="shareFromDrawer(event)">Share</button>
-                <button class="share-button" onclick="downloadFromDrawer(event)">Download</button>
+                <button class="share-button copy-button" onclick="downloadFromDrawer(event)">Download</button>
             </div>
         </div>
 
@@ -212,7 +212,8 @@ layout: default
   }
 
   function downloadReviewer(slug) {
-    fetch(`/_reviewers/${slug}.md`)
+    const url = `https://raw.githubusercontent.com/baz-scm/awesome-reviewers/main/_reviewers/${slug}.md`;
+    fetch(url)
       .then(res => {
         if (!res.ok) throw new Error('Fetch failed');
         return res.text();

--- a/_layouts/reviewer.html
+++ b/_layouts/reviewer.html
@@ -57,6 +57,7 @@ layout: default
                     <span id="copy-text">Copy Prompt</span>
                 </button>
                 <button class="share-button copy-button" onclick="shareFromDrawer(event)">Share</button>
+                <button class="share-button" onclick="downloadFromDrawer(event)">Download</button>
             </div>
         </div>
 
@@ -202,11 +203,40 @@ layout: default
       button.textContent = 'Copied!';
     } catch (err) {
       console.error('Copy failed', err);
-    } finally {
+  } finally {
       setTimeout(() => {
         button.classList.remove('copied');
         button.textContent = 'Share';
       }, 2000);
+    }
+  }
+
+  function downloadReviewer(slug) {
+    fetch(`/_reviewers/${slug}.md`)
+      .then(res => {
+        if (!res.ok) throw new Error('Fetch failed');
+        return res.text();
+      })
+      .then(text => {
+        const blob = new Blob([text], { type: 'text/markdown' });
+        const link = document.createElement('a');
+        link.href = URL.createObjectURL(blob);
+        link.download = `${slug}.agents.md`;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+      })
+      .catch(err => console.error('Download failed', err));
+  }
+
+  function downloadFromDrawer(e) {
+    let slug = location.hash.slice(1);
+    if (!slug) {
+      const parts = window.location.pathname.split('/').filter(Boolean);
+      slug = parts[parts.length - 1];
+    }
+    if (slug) {
+      downloadReviewer(slug);
     }
   }
 </script>

--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@ layout: default
                     <div class="card-actions">
                         <a href="{{ reviewer.url }}" class="fullpage-button" onclick="event.stopPropagation()">⛶</a>
                         <button class="share-button" onclick="shareFromCard(event, '{{ slug }}')">Share</button>
+                        <button class="share-button" onclick="downloadFromCard(event, '{{ slug }}')">Download</button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
# User description
## Summary
- add download button to reviewer cards and drawer
- implement JS helpers to fetch raw markdown files and download them

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bundle exec jekyll build --quiet`


------
https://chatgpt.com/codex/tasks/task_b_68862cbbe1f0832b983edfba83e18815

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Adds download functionality to reviewer cards and drawer interfaces by implementing JavaScript helpers that fetch raw markdown files from the GitHub repository and trigger browser downloads. The changes enhance both the main reviewer listing page and individual reviewer detail views with consistent download capabilities.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Revert-Add-map-view-to...</td><td>July 27, 2025</td></tr>
<tr><td>nimrodkor</td><td>Better-search-function...</td><td>July 10, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/87?tool=ast>(Baz)</a>.