### PR TITLE
Add symlink check to GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,12 @@ jobs:
           bundler-cache: true
       - name: Build site
         run: bundle exec jekyll build
+      - name: Check for symlinks in _site
+        run: |
+          echo "\U1F50D Looking for symlinks in _site"
+          find ./_site -type l
+      - name: Add .nojekyll file
+        run: touch _site/.nojekyll
       - uses: actions/upload-artifact@v4
         with:
           name: github-pages


### PR DESCRIPTION
## Summary
- check for symlinks in `_site` after building
- create `.nojekyll` file to avoid GitHub Pages processing

## Testing
- `bundle exec jekyll build`
- `find ./_site -type l`


------
https://chatgpt.com/codex/tasks/task_b_6887360c4b04832b86ed4cb3a5bad1b7