### PR TITLE
Fix leaderboard row wrapping

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1660,10 +1660,28 @@ h2 .stat-value {
 
 /* Avatar displayed in the leaderboard table */
 .lb-avatar {
-    width: 32px;
-    height: 32px;
+    width: 24px;
+    height: 24px;
     border-radius: 50%;
-    margin-right: 0.5rem;
+    margin-right: 0.25rem;
+    vertical-align: middle;
+}
+
+/* Ensure leaderboard name cells stay on one line */
+.leaderboard-table .lb-name {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 200px;
+    display: flex;
+    align-items: center;
+}
+
+.leaderboard-table .lb-name a {
+    display: inline-block;
+    max-width: 160px;
+    overflow: hidden;
+    text-overflow: ellipsis;
     vertical-align: middle;
 }
 

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -44,7 +44,7 @@ description: Top contributors powering Awesome Reviewers
           <td>{{ forloop.index }}</td>
           <td class="lb-name">
             {% if forloop.index == 1 %}🥇 {% elsif forloop.index == 2 %}🥈 {% elsif forloop.index == 3 %}🥉 {% endif %}
-            <img class="lb-avatar" src="https://github.com/{{ user.name }}.png?size=40" alt="{{ user.name }} avatar">
+            <img class="lb-avatar" src="https://github.com/{{ user.name }}.png?size=32" alt="{{ user.name }} avatar">
             <a href="https://github.com/{{ user.name }}" target="_blank" rel="noopener noreferrer">{{ user.name }}</a>
           </td>
           <td data-sort="{{ user.reviewers_count }}">{{ user.reviewers_count }}</td>


### PR DESCRIPTION
# User description
## Summary
- keep leaderboard name cells to a single line
- scale down contributor avatars

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_688880ee3020832b9e0ee1635f0b6638

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fixes leaderboard row wrapping by scaling down contributor avatars and preventing name cell text from wrapping to multiple lines. Updates the <code>lb-avatar</code> CSS class and leaderboard HTML template to create a more compact layout with proper text overflow handling.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Revert-Add-map-view-to...</td><td>July 27, 2025</td></tr>
<tr><td>nimrodkor</td><td>Spacing</td><td>July 09, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/98?tool=ast>(Baz)</a>.