### PR TITLE
Fix leaderboard metadata

### DIFF
--- a/github_utils.py
+++ b/github_utils.py
@@ -1,0 +1,29 @@
+import json
+from urllib.request import Request, urlopen
+from urllib.error import URLError, HTTPError
+
+PROFILE_FIELDS = [
+    'location',
+    'company',
+    'blog',
+    'twitter_username',
+    'email',
+    'site_admin',
+    'followers',
+    'following',
+]
+
+def fetch_profile(user, token=None):
+    """Fetch GitHub profile data for a user and return selected fields."""
+    url = f'https://api.github.com/users/{user}'
+    headers = {'Accept': 'application/vnd.github+json'}
+    if token:
+        headers['Authorization'] = f'Bearer {token}'
+    req = Request(url, headers=headers)
+    try:
+        with urlopen(req, timeout=10) as resp:
+            data = json.load(resp)
+    except (HTTPError, URLError, OSError) as exc:
+        print(f'Failed to fetch profile for {user}: {exc}')
+        return None
+    return {k: data.get(k) for k in PROFILE_FIELDS if data.get(k) is not None}


### PR DESCRIPTION
# User description
## Summary
- fetch GitHub profile data when generating the leaderboard
- cache previously fetched profiles in `contributors.json`

## Testing
- `python generate_leaderboard.py`
- `python -m py_compile generate_leaderboard.py`


------
https://chatgpt.com/codex/tasks/task_b_6888833d6c24832bb7147924a02991e5

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
main_("main"):::modified
fetch_profile_("fetch_profile"):::added
main_ -- "Adds GitHub profile fetching to enrich contributor data" --> fetch_profile_
main_ -- "Uses new API to fetch detailed GitHub user profiles" --> fetch_profile_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enhances the leaderboard generation by fetching GitHub profile metadata and implementing a caching mechanism. The <code>generate_leaderboard.py</code> script now integrates with a new <code>github_utils.py</code> module to retrieve user profile data from the GitHub API and stores this information in <code>contributors.json</code> for future reuse.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Fix-contributor-drawer...</td><td>July 24, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/99?tool=ast>(Baz)</a>.