### PR TITLE
Add reb2b analytics snippet

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -61,8 +61,38 @@
 
       gtag('config', 'G-2S2LLCMG7N');
     </script>
-</head>
-<body>
+    <script>
+        !function () {
+            var reb2b = window.reb2b = window.reb2b || [];
+            if (reb2b.invoked) return;
+            reb2b.invoked = true;
+            reb2b.methods = ["identify", "collect"];
+            reb2b.factory = function(method) {
+                return function() {
+                    var args = Array.prototype.slice.call(arguments);
+                    args.unshift(method);
+                    reb2b.push(args);
+                    return reb2b;
+                };
+            };
+            for (var i = 0; i < reb2b.methods.length; i++) {
+                var key = reb2b.methods[i];
+                reb2b[key] = reb2b.factory(key);
+            }
+            reb2b.load = function(key) {
+                var script = document.createElement("script");
+                script.type = "text/javascript";
+                script.async = true;
+                script.src = "https://b2bjsstore.s3.us-west-2.amazonaws.com/b/" + key + "/4O7Z0HJL9PNX.js.gz";
+                var first = document.getElementsByTagName("script")[0];
+                first.parentNode.insertBefore(script, first);
+            };
+            reb2b.SNIPPET_VERSION = "1.0.1";
+            reb2b.load("4O7Z0HJL9PNX");
+        }();
+    </script>
+  </head>
+  <body>
 <header class="header">
     <div class="container">
         <div class="header-content">


### PR DESCRIPTION
# User description
## Summary
- insert reb2b analytics loader in default layout

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_6889c0fa2b60832bb8edff79db96f995

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Integrates reb2b analytics tracking into the Jekyll site by adding the analytics snippet to the <code>default.html</code> layout template. The snippet initializes the reb2b tracking library and loads the analytics script to enable user behavior tracking across all pages using the default layout.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Revert-Add-AI-vs-Human...</td><td>July 28, 2025</td></tr>
<tr><td>nimrodkor</td><td>Better-search-function...</td><td>July 10, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/100?tool=ast>(Baz)</a>.