### PR TITLE
Revert sorting by update time and timeline view

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "base64"
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem "jekyll-sitemap"
-  gem "jekyll-last-modified-at"
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
@@ -25,4 +24,3 @@ gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
 # Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
 # do not have a Java counterpart.
 gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,8 +72,6 @@ GEM
       webrick (~> 1.7)
     jekyll-feed (0.17.0)
       jekyll (>= 3.7, < 5.0)
-    jekyll-last-modified-at (1.3.2)
-      jekyll (>= 3.7, < 5.0)
     jekyll-sass-converter (3.1.0)
       sass-embedded (~> 1.75)
     jekyll-seo-tag (2.8.0)
@@ -169,7 +167,6 @@ DEPENDENCIES
   http_parser.rb (~> 0.6.0)
   jekyll (~> 4.3.0)
   jekyll-feed (~> 0.12)
-  jekyll-last-modified-at
   jekyll-sitemap
   logger
   minima (~> 2.5)

--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,6 @@ collections:
 plugins:
   - jekyll-feed
   - jekyll-sitemap
-  - jekyll-last-modified-at
 
 # Exclude from processing
 exclude:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -510,8 +510,6 @@
         
         // Update URL parameters
         updateUrlParams();
-
-        insertTimelineDividers();
     }
 
     function updateReviewerCount(visible, total) {
@@ -568,42 +566,6 @@
             const num = parseFloat(el.dataset.count);
             if (!isNaN(num)) {
                 el.textContent = num.toLocaleString();
-            }
-        });
-    }
-
-    function getRelativeTime(date) {
-        const now = new Date();
-        const diff = now - date;
-        const hours = diff / 3600000;
-        const days = Math.floor(diff / 86400000);
-        if (hours < 1) return 'Last 1 Hour';
-        if (hours < 12) return 'Last 12 Hours';
-        if (days === 0) return 'Today';
-        if (days === 1) return 'Yesterday';
-        if (days < 7) return 'Last Week';
-        if (days < 14) return 'Last 2 Weeks';
-        if (days < 21) return 'Last 3 Weeks';
-        if (days < 30) return 'Last Month';
-        return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
-    }
-
-    function insertTimelineDividers() {
-        const grid = document.querySelector('.reviewer-grid');
-        if (!grid) return;
-        grid.querySelectorAll('.timeline-divider').forEach(el => el.remove());
-        const cards = Array.from(grid.querySelectorAll('.reviewer-card')).filter(c => c.style.display !== 'none');
-        let lastLabel = '';
-        cards.forEach(card => {
-            const created = card.dataset.created;
-            if (!created) return;
-            const label = getRelativeTime(new Date(created));
-            if (label !== lastLabel) {
-                const divider = document.createElement('div');
-                divider.className = 'timeline-divider';
-                divider.textContent = label;
-                grid.insertBefore(divider, card);
-                lastLabel = label;
             }
         });
     }
@@ -684,7 +646,6 @@
                 loadDiscussions(pageSlug);
             }
         }
-        window.addEventListener('resize', insertTimelineDividers);
     });
 
     function openDrawer(slug) {

--- a/_layouts/reviewer.html
+++ b/_layouts/reviewer.html
@@ -30,13 +30,6 @@ layout: default
             </div>
             <div class="meta-item">
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 1.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13Zm0 11.5A5 5 0 1 1 8 3a5 5 0 0 1 0 10Z"/>
-                    <path d="M8.75 4.75a.75.75 0 0 0-1.5 0v3.5c0 .414.336.75.75.75h3.5a.75.75 0 0 0 0-1.5H8.75V4.75Z"/>
-                </svg>
-                Created <time datetime="{{ page.last_modified_at | date_to_xmlschema }}">{{ page.last_modified_at | date: "%b %-d, %Y" }}</time>
-            </div>
-            <div class="meta-item">
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
                     <path d="M11.013 1.427a1.75 1.75 0 0 1 2.474 0l1.086 1.086a1.75 1.75 0 0 1 0 2.474l-8.61 8.61c-.21.21-.47.364-.756.445l-3.251.93a.75.75 0 0 1-.927-.928l.929-3.25c.081-.286.235-.547.445-.758l8.61-8.61Zm.176 4.823L9.75 4.81l-6.286 6.287a.253.253 0 0 0-.064.108l-.558 1.953 1.953-.558a.253.253 0 0 0 .108-.064Zm1.238-3.763a.25.25 0 0 0-.354 0L10.811 3.75l1.439 1.44 1.263-1.263a.25.25 0 0 0 0-.354Z"/>
                 </svg>
                 {{ page.language }}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -656,32 +656,6 @@ h1, h2, h3, h4, h5, h6 {
     margin-top: 2rem;
 }
 
-.timeline-divider {
-    display: flex;
-    align-items: center;
-    margin: 2rem 0 1rem;
-    color: var(--text-muted);
-    font-size: 0.875rem;
-    font-weight: 500;
-    grid-column: 1 / -1;
-}
-
-.timeline-divider::before,
-.timeline-divider::after {
-    content: "";
-    flex: 1;
-    height: 1px;
-    background: var(--border);
-}
-
-.timeline-divider::before {
-    margin-right: 0.5rem;
-}
-
-.timeline-divider::after {
-    margin-left: 0.5rem;
-}
-
 .extra-reviewer {
     display: none;
 }

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@ layout: default
 <main class="main-content">
     <div class="container">
         <div class="reviewer-grid">
-            {% assign sorted_reviewers = site.reviewers | sort: "last_modified_at" | reverse %}
+            {% assign sorted_reviewers = site.reviewers | sort: "comments_count" | reverse %}
             {% assign initial_limit = 100 %}
             {% for reviewer in sorted_reviewers %}
             {% assign index = forloop.index0 %}
@@ -47,8 +47,7 @@ layout: default
             <div class="reviewer-card{% if index >= initial_limit %} extra-reviewer{% endif %}" id="{{ slug }}" data-slug="{{ slug }}"
                  data-repo="{{ reviewer.repository }}"
                  data-category="{{ reviewer.label }}"
-                 data-language="{{ reviewer.language }}"
-                 data-created="{{ reviewer.last_modified_at | date_to_xmlschema }}">
+                 data-language="{{ reviewer.language }}">
                 <div class="reviewer-header">
                     <div>
                         <h3 class="reviewer-title">{{ reviewer.title }}</h3>


### PR DESCRIPTION
## Summary
- revert addition of reviewer sorting by last update and timeline display
- remove timeline-specific gems and assets

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_688f65d7dc74832b9e7de49dc21b7022