### PR TITLE
Add feed view with toggle

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -464,6 +464,9 @@
             selectedLanguages.length === 0;
 
         cards.forEach(card => {
+            const parent = card.closest('.reviewer-grid, .reviewer-feed');
+            const parentHidden = parent && parent.style.display === 'none';
+
             const titleEl = card.querySelector('.reviewer-title');
             const descriptionEl = card.querySelector('.reviewer-description');
             const title = titleEl ? titleEl.textContent.toLowerCase() : '';
@@ -493,7 +496,7 @@
                     card.style.display = 'none';
                 } else {
                     card.style.display = 'block';
-                    visibleCount++;
+                    if (!parentHidden) visibleCount++;
                 }
             } else {
                 card.style.display = 'none';
@@ -501,10 +504,11 @@
         });
 
         // Update the reviewer count
+        const totalUnique = document.querySelectorAll('.reviewer-grid .reviewer-card').length;
         updateReviewerCount(
             visibleCount,
             initialView && document.getElementById('load-more')
-                ? cards.length
+                ? totalUnique
                 : null
         );
         
@@ -637,6 +641,27 @@
             if (slug && document.getElementById(slug)) {
                 openDrawer(slug);
             }
+        }
+
+        const gridContainer = document.querySelector('.reviewer-grid');
+        const feedContainer = document.getElementById('feed-view');
+        const toggleBtn = document.getElementById('toggle-view');
+        if (gridContainer && feedContainer && toggleBtn) {
+            toggleBtn.addEventListener('click', () => {
+                const showingFeed = feedContainer.style.display !== 'none';
+                if (showingFeed) {
+                    feedContainer.style.display = 'none';
+                    gridContainer.style.display = 'grid';
+                    toggleBtn.textContent = 'Feed View';
+                    toggleBtn.setAttribute('aria-label', 'Switch to Feed View');
+                } else {
+                    gridContainer.style.display = 'none';
+                    feedContainer.style.display = 'block';
+                    toggleBtn.textContent = 'Grid View';
+                    toggleBtn.setAttribute('aria-label', 'Switch to Grid View');
+                }
+                filterReviewers();
+            });
         }
 
         if (document.getElementById('discussion-container')) {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -656,6 +656,18 @@ h1, h2, h3, h4, h5, h6 {
     margin-top: 2rem;
 }
 
+.reviewer-feed {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    margin-top: 2rem;
+}
+
+.reviewer-feed .reviewer-card {
+    width: 100%;
+    padding-bottom: 4rem;
+}
+
 .extra-reviewer {
     display: none;
 }
@@ -1648,6 +1660,21 @@ h2 .stat-value {
 
 .add-repo-btn:hover {
     background: var(--accent-hover);
+}
+
+.toggle-view-btn {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    color: var(--text-primary);
+    padding: 0.375rem 0.75rem;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.875rem;
+    transition: background-color 0.2s ease;
+}
+
+.toggle-view-btn:hover {
+    background: var(--bg-secondary);
 }
 
 .avatar {

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@ layout: default
 <section class="library-header">
     <div class="container">
         <h2>Reviewers Library (<span id="reviewer-count" class="stat-value" data-total="{{ site.reviewers.size }}">{{ site.reviewers.size }}</span>)</h2>
+        <button id="toggle-view" class="toggle-view-btn" aria-label="Switch to Feed View">Feed View</button>
         <button id="add-repo-button" class="add-repo-btn">Add Repository</button>
     </div>
 </section>
@@ -38,9 +39,9 @@ layout: default
 
 <main class="main-content">
     <div class="container">
+        {% assign sorted_reviewers = site.reviewers | sort: "comments_count" | reverse %}
+        {% assign initial_limit = 100 %}
         <div class="reviewer-grid">
-            {% assign sorted_reviewers = site.reviewers | sort: "comments_count" | reverse %}
-            {% assign initial_limit = 100 %}
             {% for reviewer in sorted_reviewers %}
             {% assign index = forloop.index0 %}
             {% assign slug = reviewer.url | remove: '/reviewers/' | remove: '/' %}
@@ -72,6 +73,52 @@ layout: default
                 </div>
 
                 <p class="reviewer-description">{{ reviewer.description | truncate: 120 }}</p>
+
+                <div class="reviewer-meta">
+                    <div class="reviewer-tags">
+                        <span class="tag">{{ reviewer.label }}</span>
+                        <span class="tag language">{{ reviewer.language }}</span>
+                    </div>
+                    <div class="card-actions">
+                        <a href="{{ reviewer.url }}" class="fullpage-button" onclick="event.stopPropagation()">⛶</a>
+                        <button class="share-button" onclick="shareFromCard(event, '{{ slug }}')">Share</button>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+        <div class="reviewer-feed" id="feed-view" style="display:none;">
+            {% for reviewer in sorted_reviewers %}
+            {% assign index = forloop.index0 %}
+            {% assign slug = reviewer.url | remove: '/reviewers/' | remove: '/' %}
+            <div class="reviewer-card{% if index >= initial_limit %} extra-reviewer{% endif %}" id="{{ slug }}-feed" data-slug="{{ slug }}"
+                 data-repo="{{ reviewer.repository }}"
+                 data-category="{{ reviewer.label }}"
+                 data-language="{{ reviewer.language }}">
+                <div class="reviewer-header">
+                    <div>
+                        <h3 class="reviewer-title">{{ reviewer.title }}</h3>
+                        <a class="reviewer-repo" href="https://github.com/{{ reviewer.repository }}" target="_blank" rel="noopener noreferrer">
+                            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                                <path d="M8.21.07l6 3A.75.75 0 0 1 15 3.75V12a.75.75 0 0 1-.4.67l-6 3a.75.75 0 0 1-.6 0l-6-3A.75.75 0 0 1 1 12V3.75a.75.75 0 0 1 .39-.68l6-3a.75.75 0 0 1 .82 0ZM8 1.26 3.25 3.48 8 5.74l4.75-2.26L8 1.26ZM2.5 4.97v6.54l5 2.5V7.47l-5-2.5Zm11 6.54V4.97l-5 2.5v6.54l5-2.5Z"/>
+                            </svg>
+                            {{ reviewer.repository }}
+                        </a>
+                    </div>
+                    <div class="reviewer-stats">
+                        <div class="stat-item stat-comments">
+                            <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+                                <path d="M1.75 2.5A.75.75 0 0 1 2.5 1.75h11a.75.75 0 0 1 .75.75v8.5a.75.75 0 0 1-.75.75H6.4l-3.52 3.2a.75.75 0 0 1-1.28-.55V2.5Z"/>
+                            </svg>
+                            <span class="stat-value" data-count="{{ reviewer.comments_count | default: 0 }}">{{ reviewer.comments_count | default: 0 }}</span>
+                        </div>
+                        <div class="stat-item stat-stars">
+                            ⭐ <span class="stat-value" data-count="{{ reviewer.repository_stars | default: 0 }}">{{ reviewer.repository_stars | default: 0 }}</span>
+                        </div>
+                    </div>
+                </div>
+
+                <p class="reviewer-description">{{ reviewer.description }}</p>
 
                 <div class="reviewer-meta">
                     <div class="reviewer-tags">


### PR DESCRIPTION
## Summary
- add feed-style reviewer list and toggle button on homepage
- style feed and toggle, ensuring one-column layout
- unify filtering for both views and implement JS view switch

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_688fc3b23bc8832ba74daf284133c538