### PR TITLE
Fix Liquid syntax in DuckDB logging example

### DIFF
--- a/_reviewers/duckdb-guard-expensive-logging-operations.md
+++ b/_reviewers/duckdb-guard-expensive-logging-operations.md
@@ -16,12 +16,14 @@ Avoid executing expensive operations in logging code paths when logging is disab
 The key principle is to separate the lightweight "should log" check from expensive log message preparation. This prevents performance overhead when logging is disabled and avoids unnecessary work like duplicate string construction or complex data processing.
 
 Example of the problem:
+{% raw %}
 ```cpp
 // BAD: Always executes expensive operation
 const auto event = state.offset_in_group == (idx_t)group.num_rows ? "SkipRowGroup" : "ReadRowGroup";
-DUCKDB_LOG(context, PhysicalOperatorLogType, *state.op, "ParquetReader", event, 
+DUCKDB_LOG(context, PhysicalOperatorLogType, *state.op, "ParquetReader", event,
            {{"file", file.path}, {"row_group_id", to_string(state.group_idx_list[state.current_group])}});
 ```
+{% endraw %}
 
 Better approach:
 ```cpp


### PR DESCRIPTION
# User description
## Summary
- escape Liquid syntax in DuckDB logging snippet using `{% raw %}`

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_b_68ab38100d34832b80047b95f53db71b

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Escapes Liquid syntax in a DuckDB logging example to ensure correct rendering of the C++ code snippet. Prevents Jekyll from misinterpreting the example code as Liquid template tags.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>internal-baz-ci-app[bot]</td><td>Add-34-awesome-reviewe...</td><td>August 19, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/107?tool=ast>(Baz)</a>.