### PR TITLE
Add landing-page trending section

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -2071,6 +2071,12 @@ h2 .stat-value {
     font-size: 0.75rem;
 }
 
+.trend-stat .stat-label {
+    color: var(--text-secondary);
+    margin-right: 0.25rem;
+    font-size: inherit;
+}
+
 .browse-link {
     margin-top: auto;
     font-size: 0.875rem;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1995,3 +1995,73 @@ h2 .stat-value {
     color: var(--accent);
     margin-left: 0.25rem;
 }
+
+/* Trending section */
+.trending {
+    padding: 2rem 0;
+}
+
+.trending-title {
+    text-align: center;
+    font-size: 1.5rem;
+    margin: 0 0 0.25rem;
+}
+
+.trending-description {
+    text-align: center;
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+    margin-bottom: 1.5rem;
+}
+
+.trending-grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.trending-column {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 1rem;
+    box-shadow: var(--shadow);
+    display: flex;
+    flex-direction: column;
+}
+
+.trending-column h3 {
+    margin: 0 0 0.5rem;
+    font-size: 1.1rem;
+}
+
+.trending-column ul {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 1rem;
+    flex: 1 1 auto;
+}
+
+.trending-column li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.25rem 0;
+}
+
+.trend-stat {
+    color: var(--text-muted);
+    font-size: 0.875rem;
+}
+
+.browse-link {
+    margin-top: auto;
+    font-size: 0.875rem;
+    color: var(--accent);
+    text-decoration: none;
+}
+
+.browse-link:hover {
+    color: var(--accent-hover);
+    text-decoration: underline;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -2035,6 +2035,12 @@ h2 .stat-value {
     font-size: 1.1rem;
 }
 
+.trending-category-desc {
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    margin: 0 0 0.75rem;
+}
+
 .trending-column ul {
     list-style: none;
     padding: 0;
@@ -2049,9 +2055,20 @@ h2 .stat-value {
     padding: 0.25rem 0;
 }
 
+.trend-name {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.trend-stats {
+    display: flex;
+    gap: 0.5rem;
+}
+
 .trend-stat {
     color: var(--text-muted);
-    font-size: 0.875rem;
+    font-size: 0.75rem;
 }
 
 .browse-link {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -115,3 +115,25 @@ if (menuToggle && headerEl) {
     if (closeIcon) closeIcon.style.display = open ? 'block' : 'none';
   });
 }
+
+function formatStars(count) {
+  if (count >= 1000) {
+    return (count / 1000).toFixed(1).replace(/\.0$/, '') + 'k';
+  }
+  return count.toString();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[data-stars]').forEach(el => {
+    const count = parseInt(el.getAttribute('data-stars'), 10);
+    if (!isNaN(count)) {
+      el.textContent = `⭐ ${formatStars(count)}`;
+    }
+  });
+  document.querySelectorAll('.stat-stars .stat-value').forEach(el => {
+    const count = parseInt(el.getAttribute('data-count'), 10);
+    if (!isNaN(count)) {
+      el.textContent = formatStars(count);
+    }
+  });
+});

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -116,24 +116,3 @@ if (menuToggle && headerEl) {
   });
 }
 
-function formatStars(count) {
-  if (count >= 1000) {
-    return (count / 1000).toFixed(1).replace(/\.0$/, '') + 'k';
-  }
-  return count.toString();
-}
-
-document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('[data-stars]').forEach(el => {
-    const count = parseInt(el.getAttribute('data-stars'), 10);
-    if (!isNaN(count)) {
-      el.textContent = formatStars(count);
-    }
-  });
-  document.querySelectorAll('.stat-stars .stat-value').forEach(el => {
-    const count = parseInt(el.getAttribute('data-count'), 10);
-    if (!isNaN(count)) {
-      el.textContent = formatStars(count);
-    }
-  });
-});

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -127,7 +127,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('[data-stars]').forEach(el => {
     const count = parseInt(el.getAttribute('data-stars'), 10);
     if (!isNaN(count)) {
-      el.textContent = `⭐ ${formatStars(count)}`;
+      el.textContent = formatStars(count);
     }
   });
   document.querySelectorAll('.stat-stars .stat-value').forEach(el => {

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@ layout: default
             {% assign top_reviewers = site.reviewers | sort: "comments_count" | reverse | slice: 0,5 %}
             <div class="trending-column">
                 <h3>💬 Reviewers</h3>
-                <p class="trending-category-desc">Prompt generators with the most comments and stars</p>
+                <p class="trending-category-desc">Prompt generators with the most comments</p>
                 <ul>
                     {% for reviewer in top_reviewers %}
                     {% assign slug = reviewer.url | remove: '/reviewers/' | remove: '/' %}
@@ -70,8 +70,6 @@ layout: default
                         </span>
                         <span class="trend-stats">
                             <span class="trend-stat"><span class="stat-label">Comments:</span> {{ reviewer.comments_count | default: 0 }}</span>
-                            {% assign stars = reviewer.repository_stars | default: 0 %}
-                            <span class="trend-stat"><span class="stat-label">Stars:</span> <span class="trend-value" data-stars="{{ stars }}">{{ stars }}</span></span>
                         </span>
                     </li>
                     {% endfor %}
@@ -135,10 +133,6 @@ layout: default
                         <div class="stat-item stat-comments">
                             <span class="stat-label">Comments:</span>
                             <span class="stat-value" data-count="{{ reviewer.comments_count | default: 0 }}">{{ reviewer.comments_count | default: 0 }}</span>
-                        </div>
-                        <div class="stat-item stat-stars">
-                            <span class="stat-label">Stars:</span>
-                            <span class="stat-value" data-count="{{ reviewer.repository_stars | default: 0 }}">{{ reviewer.repository_stars | default: 0 }}</span>
                         </div>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,57 @@ layout: default
     </div>
 </section>
 
+<section class="trending">
+    <div class="container">
+        <h2 class="trending-title">Trending on ✨ this week</h2>
+        <p class="trending-description">Browse {{ site.reviewers.size }} reviewers from {{ site.data.orgs.orgs | size }} orgs and {{ site.data.leaderboard | size }} contributors</p>
+        <div class="trending-grid">
+            {% assign top_orgs = site.data.orgs.orgs | sort: "reviewers_count" | reverse | slice: 0,5 %}
+            <div class="trending-column">
+                <h3>Organizations</h3>
+                <ul>
+                    {% for org in top_orgs %}
+                    <li>
+                        <a href="/orgs.html#{{ org.name }}">{{ org.name }}</a>
+                        <span class="trend-stat">{{ org.reviewers_count }} reviewers</span>
+                    </li>
+                    {% endfor %}
+                </ul>
+                <a class="browse-link" href="/orgs.html">Browse {{ site.data.orgs.orgs | size }} orgs</a>
+            </div>
+
+            {% assign top_contributors = site.data.leaderboard | slice: 0,5 %}
+            <div class="trending-column">
+                <h3>Contributors</h3>
+                <ul>
+                    {% for user in top_contributors %}
+                    <li>
+                        <a href="/leaderboard.html#{{ user.name }}">{{ user.name }}</a>
+                        <span class="trend-stat">{{ user.reviewers_count }} reviewers</span>
+                    </li>
+                    {% endfor %}
+                </ul>
+                <a class="browse-link" href="/leaderboard.html">Browse {{ site.data.leaderboard | size }} contributors</a>
+            </div>
+
+            {% assign top_reviewers = site.reviewers | sort: "comments_count" | reverse | slice: 0,5 %}
+            <div class="trending-column">
+                <h3>Reviewers</h3>
+                <ul>
+                    {% for reviewer in top_reviewers %}
+                    {% assign slug = reviewer.url | remove: '/reviewers/' | remove: '/' %}
+                    <li>
+                        <a href="#{{ slug }}" onclick="openDrawer('{{ slug }}'); return false;">{{ reviewer.title }}</a>
+                        <span class="trend-stat">{{ reviewer.comments_count | default: 0 }} comments</span>
+                    </li>
+                    {% endfor %}
+                </ul>
+                <a class="browse-link" href="#reviewer-count" onclick="document.querySelector('.library-header').scrollIntoView({behavior:'smooth'}); return false;">Browse {{ site.reviewers.size }} reviewers</a>
+            </div>
+        </div>
+    </div>
+</section>
+
 <section class="library-header">
     <div class="container">
         <h2>Reviewers Library (<span id="reviewer-count" class="stat-value" data-total="{{ site.reviewers.size }}">{{ site.reviewers.size }}</span>)</h2>

--- a/index.html
+++ b/index.html
@@ -22,12 +22,12 @@ layout: default
                     {% for org in top_orgs %}
                     <li>
                         <span class="trend-name">
-                            {% if forloop.index == 1 %}🥇 {% elsif forloop.index == 2 %}🥈 {% elsif forloop.index == 3 %}🥉 {% endif %}🏢
+                            {% if forloop.index == 1 %}🥇 {% elsif forloop.index == 2 %}🥈 {% elsif forloop.index == 3 %}🥉 {% endif %}
                             <a href="/orgs/#{{ org.name }}">{{ org.name }}</a>
                         </span>
                         <span class="trend-stats">
-                            <span class="trend-stat">{{ org.reviewers_count }} {{ org.reviewers_count | pluralize: 'reviewer', 'reviewers' }}</span>
-                            <span class="trend-stat">{{ org.repos_count }} {{ org.repos_count | pluralize: 'repo', 'repos' }}</span>
+                            <span class="trend-stat"><span class="stat-label">Reviewers:</span> {{ org.reviewers_count }}</span>
+                            <span class="trend-stat"><span class="stat-label">Repos:</span> {{ org.repos_count }}</span>
                         </span>
                     </li>
                     {% endfor %}
@@ -43,12 +43,12 @@ layout: default
                     {% for user in top_contributors %}
                     <li>
                         <span class="trend-name">
-                            {% if forloop.index == 1 %}🥇 {% elsif forloop.index == 2 %}🥈 {% elsif forloop.index == 3 %}🥉 {% endif %}👤
+                            {% if forloop.index == 1 %}🥇 {% elsif forloop.index == 2 %}🥈 {% elsif forloop.index == 3 %}🥉 {% endif %}
                             <a href="/leaderboard/#{{ user.name }}">{{ user.name }}</a>
                         </span>
                         <span class="trend-stats">
-                            <span class="trend-stat">{{ user.reviewers_count }} {{ user.reviewers_count | pluralize: 'reviewer', 'reviewers' }}</span>
-                            <span class="trend-stat">{{ user.repos_count }} {{ user.repos_count | pluralize: 'repo', 'repos' }}</span>
+                            <span class="trend-stat"><span class="stat-label">Reviewers:</span> {{ user.reviewers_count }}</span>
+                            <span class="trend-stat"><span class="stat-label">Repos:</span> {{ user.repos_count }}</span>
                         </span>
                     </li>
                     {% endfor %}
@@ -65,13 +65,13 @@ layout: default
                     {% assign slug = reviewer.url | remove: '/reviewers/' | remove: '/' %}
                     <li>
                         <span class="trend-name">
-                            {% if forloop.index == 1 %}🥇 {% elsif forloop.index == 2 %}🥈 {% elsif forloop.index == 3 %}🥉 {% endif %}💬
+                            {% if forloop.index == 1 %}🥇 {% elsif forloop.index == 2 %}🥈 {% elsif forloop.index == 3 %}🥉 {% endif %}
                             <a href="#{{ slug }}" onclick="openDrawer('{{ slug }}'); return false;">{{ reviewer.title }}</a>
                         </span>
                         <span class="trend-stats">
-                            <span class="trend-stat">{{ reviewer.comments_count | default: 0 }} {{ reviewer.comments_count | default: 0 | pluralize: 'comment', 'comments' }}</span>
+                            <span class="trend-stat"><span class="stat-label">Comments:</span> {{ reviewer.comments_count | default: 0 }}</span>
                             {% assign stars = reviewer.repository_stars | default: 0 %}
-                            <span class="trend-stat" data-stars="{{ stars }}">⭐ {{ stars }}</span>
+                            <span class="trend-stat"><span class="stat-label">Stars:</span> <span class="trend-value" data-stars="{{ stars }}">{{ stars }}</span></span>
                         </span>
                     </li>
                     {% endfor %}
@@ -133,13 +133,12 @@ layout: default
                     </div>
                     <div class="reviewer-stats">
                         <div class="stat-item stat-comments">
-                            <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-                                <path d="M1.75 2.5A.75.75 0 0 1 2.5 1.75h11a.75.75 0 0 1 .75.75v8.5a.75.75 0 0 1-.75.75H6.4l-3.52 3.2a.75.75 0 0 1-1.28-.55V2.5Z"/>
-                            </svg>
+                            <span class="stat-label">Comments:</span>
                             <span class="stat-value" data-count="{{ reviewer.comments_count | default: 0 }}">{{ reviewer.comments_count | default: 0 }}</span>
                         </div>
                         <div class="stat-item stat-stars">
-                            ⭐ <span class="stat-value" data-count="{{ reviewer.repository_stars | default: 0 }}">{{ reviewer.repository_stars | default: 0 }}</span>
+                            <span class="stat-label">Stars:</span>
+                            <span class="stat-value" data-count="{{ reviewer.repository_stars | default: 0 }}">{{ reviewer.repository_stars | default: 0 }}</span>
                         </div>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -16,41 +16,62 @@ layout: default
         <div class="trending-grid">
             {% assign top_orgs = site.data.orgs.orgs | sort: "reviewers_count" | reverse | slice: 0,5 %}
             <div class="trending-column">
-                <h3>Organizations</h3>
+                <h3>🏢 Organizations</h3>
+                <p class="trending-category-desc">Groups with the most reviewers and repos</p>
                 <ul>
                     {% for org in top_orgs %}
                     <li>
-                        <a href="/orgs.html#{{ org.name }}">{{ org.name }}</a>
-                        <span class="trend-stat">{{ org.reviewers_count }} reviewers</span>
+                        <span class="trend-name">
+                            {% if forloop.index == 1 %}🥇 {% elsif forloop.index == 2 %}🥈 {% elsif forloop.index == 3 %}🥉 {% endif %}🏢
+                            <a href="/orgs/#{{ org.name }}">{{ org.name }}</a>
+                        </span>
+                        <span class="trend-stats">
+                            <span class="trend-stat">{{ org.reviewers_count }} reviewers</span>
+                            <span class="trend-stat">{{ org.repos_count }} repos</span>
+                        </span>
                     </li>
                     {% endfor %}
                 </ul>
-                <a class="browse-link" href="/orgs.html">Browse {{ site.data.orgs.orgs | size }} orgs</a>
+                <a class="browse-link" href="/orgs/">Browse {{ site.data.orgs.orgs | size }} orgs</a>
             </div>
 
             {% assign top_contributors = site.data.leaderboard | slice: 0,5 %}
             <div class="trending-column">
-                <h3>Contributors</h3>
+                <h3>👤 Contributors</h3>
+                <p class="trending-category-desc">Folks adding the most reviewers and repos</p>
                 <ul>
                     {% for user in top_contributors %}
                     <li>
-                        <a href="/leaderboard.html#{{ user.name }}">{{ user.name }}</a>
-                        <span class="trend-stat">{{ user.reviewers_count }} reviewers</span>
+                        <span class="trend-name">
+                            {% if forloop.index == 1 %}🥇 {% elsif forloop.index == 2 %}🥈 {% elsif forloop.index == 3 %}🥉 {% endif %}👤
+                            <a href="/leaderboard/#{{ user.name }}">{{ user.name }}</a>
+                        </span>
+                        <span class="trend-stats">
+                            <span class="trend-stat">{{ user.reviewers_count }} reviewers</span>
+                            <span class="trend-stat">{{ user.repos_count }} repos</span>
+                        </span>
                     </li>
                     {% endfor %}
                 </ul>
-                <a class="browse-link" href="/leaderboard.html">Browse {{ site.data.leaderboard | size }} contributors</a>
+                <a class="browse-link" href="/leaderboard/">Browse {{ site.data.leaderboard | size }} contributors</a>
             </div>
 
             {% assign top_reviewers = site.reviewers | sort: "comments_count" | reverse | slice: 0,5 %}
             <div class="trending-column">
-                <h3>Reviewers</h3>
+                <h3>💬 Reviewers</h3>
+                <p class="trending-category-desc">Prompt generators with the most comments and stars</p>
                 <ul>
                     {% for reviewer in top_reviewers %}
                     {% assign slug = reviewer.url | remove: '/reviewers/' | remove: '/' %}
                     <li>
-                        <a href="#{{ slug }}" onclick="openDrawer('{{ slug }}'); return false;">{{ reviewer.title }}</a>
-                        <span class="trend-stat">{{ reviewer.comments_count | default: 0 }} comments</span>
+                        <span class="trend-name">
+                            {% if forloop.index == 1 %}🥇 {% elsif forloop.index == 2 %}🥈 {% elsif forloop.index == 3 %}🥉 {% endif %}💬
+                            <a href="#{{ slug }}" onclick="openDrawer('{{ slug }}'); return false;">{{ reviewer.title }}</a>
+                        </span>
+                        <span class="trend-stats">
+                            <span class="trend-stat">{{ reviewer.comments_count | default: 0 }} comments</span>
+                            <span class="trend-stat">⭐ {{ reviewer.repository_stars | default: 0 }}</span>
+                        </span>
                     </li>
                     {% endfor %}
                 </ul>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ layout: default
 <section class="trending">
     <div class="container">
         <h2 class="trending-title">Trending on ✨ this week</h2>
-        <p class="trending-description">Browse {{ site.reviewers.size }} reviewers from {{ site.data.orgs.orgs | size }} orgs and {{ site.data.leaderboard | size }} contributors</p>
+        <p class="trending-description">Browse {{ site.reviewers.size }} {{ site.reviewers.size | pluralize: 'reviewer', 'reviewers' }} from {{ site.data.orgs.orgs | size }} {{ site.data.orgs.orgs | size | pluralize: 'org', 'orgs' }} and {{ site.data.leaderboard | size }} {{ site.data.leaderboard | size | pluralize: 'contributor', 'contributors' }}</p>
         <div class="trending-grid">
             {% assign top_orgs = site.data.orgs.orgs | sort: "reviewers_count" | reverse | slice: 0,5 %}
             <div class="trending-column">
@@ -26,8 +26,8 @@ layout: default
                             <a href="/orgs/#{{ org.name }}">{{ org.name }}</a>
                         </span>
                         <span class="trend-stats">
-                            <span class="trend-stat">{{ org.reviewers_count }} reviewers</span>
-                            <span class="trend-stat">{{ org.repos_count }} repos</span>
+                            <span class="trend-stat">{{ org.reviewers_count }} {{ org.reviewers_count | pluralize: 'reviewer', 'reviewers' }}</span>
+                            <span class="trend-stat">{{ org.repos_count }} {{ org.repos_count | pluralize: 'repo', 'repos' }}</span>
                         </span>
                     </li>
                     {% endfor %}
@@ -47,8 +47,8 @@ layout: default
                             <a href="/leaderboard/#{{ user.name }}">{{ user.name }}</a>
                         </span>
                         <span class="trend-stats">
-                            <span class="trend-stat">{{ user.reviewers_count }} reviewers</span>
-                            <span class="trend-stat">{{ user.repos_count }} repos</span>
+                            <span class="trend-stat">{{ user.reviewers_count }} {{ user.reviewers_count | pluralize: 'reviewer', 'reviewers' }}</span>
+                            <span class="trend-stat">{{ user.repos_count }} {{ user.repos_count | pluralize: 'repo', 'repos' }}</span>
                         </span>
                     </li>
                     {% endfor %}
@@ -69,8 +69,9 @@ layout: default
                             <a href="#{{ slug }}" onclick="openDrawer('{{ slug }}'); return false;">{{ reviewer.title }}</a>
                         </span>
                         <span class="trend-stats">
-                            <span class="trend-stat">{{ reviewer.comments_count | default: 0 }} comments</span>
-                            <span class="trend-stat">⭐ {{ reviewer.repository_stars | default: 0 }}</span>
+                            <span class="trend-stat">{{ reviewer.comments_count | default: 0 }} {{ reviewer.comments_count | default: 0 | pluralize: 'comment', 'comments' }}</span>
+                            {% assign stars = reviewer.repository_stars | default: 0 %}
+                            <span class="trend-stat" data-stars="{{ stars }}">⭐ {{ stars }}</span>
                         </span>
                     </li>
                     {% endfor %}

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -206,9 +206,9 @@ function openContributorDrawer(user) {
   stats.className = 'contrib-stats';
   const totalComments = info.comments ? Object.values(info.comments).reduce((a,b) => a + b.length, 0) : 0;
   stats.innerHTML = `
-    <div class="contrib-stat"><span class="contrib-stat-value">${info.repos.length}</span>Repos</div>
-    <div class="contrib-stat"><span class="contrib-stat-value">${info.entries.length}</span>Entries</div>
-    <div class="contrib-stat"><span class="contrib-stat-value">${totalComments}</span>Comments</div>
+    <div class="contrib-stat"><span class="contrib-stat-value">${info.repos.length}</span>${info.repos.length === 1 ? 'Repo' : 'Repos'}</div>
+    <div class="contrib-stat"><span class="contrib-stat-value">${info.entries.length}</span>${info.entries.length === 1 ? 'Entry' : 'Entries'}</div>
+    <div class="contrib-stat"><span class="contrib-stat-value">${totalComments}</span>${totalComments === 1 ? 'Comment' : 'Comments'}</div>
   `;
   infoBox.appendChild(stats);
 
@@ -299,7 +299,7 @@ function openContributorDrawer(user) {
     return details;
   }
 
-  const reposDetails = createSection('Repositories', info.repos.length);
+  const reposDetails = createSection(info.repos.length === 1 ? 'Repository' : 'Repositories', info.repos.length);
   const repoList = document.createElement('ul');
   info.repos.forEach(r => {
     const li = document.createElement('li');

--- a/orgs.html
+++ b/orgs.html
@@ -243,6 +243,11 @@ document.querySelectorAll('#org-table tbody tr').forEach(row => {
   });
 });
 
+const initialOrg = location.hash.slice(1);
+if (initialOrg) {
+  openOrgDrawer(initialOrg);
+}
+
 const filterInput = document.getElementById('org-filter');
 filterInput.addEventListener('input', () => {
   const q = filterInput.value.toLowerCase();


### PR DESCRIPTION
# User description
## Summary
- showcase top orgs, contributors, and reviewers on landing page
- style new trending component to match site aesthetic
- allow org drawers to open directly via URL hash

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_68ac26e0dab8832b849a14ab72e4b27b

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduces a new trending section on the landing page to highlight top organizations, contributors, and reviewers, enhancing content discoverability. Additionally, it enables direct navigation to specific organization details via URL hashes and refines minor UI text for improved clarity.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/baz-scm/awesome-reviewers/113?tool=ast&topic=Minor+UI+Refinements>Minor UI Refinements</a>
        </td><td>Refines minor user interface elements and text across the application, specifically by adjusting pluralization for statistical labels on the leaderboard page and cleaning up the display of reviewer statistics on the main page for improved clarity and consistency.<details><summary>Modified files (2)</summary><ul><li>leaderboard.html</li>
<li>index.html</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Revert-Sort-reviewers-...</td><td>August 03, 2025</td></tr>
<tr><td>nimrodkor</td><td>Better-search-function...</td><td>July 10, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/baz-scm/awesome-reviewers/113?tool=ast&topic=Other>Other</a>
        </td><td>Other files<details><summary>Modified files (1)</summary><ul><li>assets/js/main.js</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Improve-header-respons...</td><td>July 24, 2025</td></tr>
<tr><td>nimrodkor</td><td>Move-footers-to-header</td><td>July 09, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/baz-scm/awesome-reviewers/113?tool=ast&topic=Landing+Page+Trending>Landing Page Trending</a>
        </td><td>Adds a new prominent 'Trending' section to the main landing page, showcasing top organizations, contributors, and reviewers based on various metrics, thereby enhancing content discoverability and highlighting key entities within the system. This includes both the structural HTML elements and their corresponding CSS styling.<details><summary>Modified files (2)</summary><ul><li>index.html</li>
<li>assets/css/main.scss</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Add-organization-view-...</td><td>August 25, 2025</td></tr>
<tr><td>nimrodkor</td><td>Better-search-function...</td><td>July 10, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/baz-scm/awesome-reviewers/113?tool=ast&topic=Org+Deep+Linking>Org Deep Linking</a>
        </td><td>Implements functionality within the organization's page to allow direct navigation and opening of specific organization detail drawers by parsing URL hashes, significantly improving shareability and user experience for accessing individual organization profiles.<details><summary>Modified files (1)</summary><ul><li>orgs.html</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>feat-display-AI-code-r...</td><td>August 25, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/113?tool=ast>(Baz)</a>.