### PR TITLE
Fix homepage pluralization in trending description

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,14 @@ layout: default
 <section class="trending">
     <div class="container">
         <h2 class="trending-title">Trending on ✨ this week</h2>
-        <p class="trending-description">Browse {{ site.reviewers.size }} {{ site.reviewers.size | pluralize: 'reviewer', 'reviewers' }} from {{ site.data.orgs.orgs | size }} {{ site.data.orgs.orgs | size | pluralize: 'org', 'orgs' }} and {{ site.data.leaderboard | size }} {{ site.data.leaderboard | size | pluralize: 'contributor', 'contributors' }}</p>
+        {% assign reviewer_count = site.reviewers.size %}
+        {% assign org_count = site.data.orgs.orgs | size %}
+        {% assign contributor_count = site.data.leaderboard | size %}
+        <p class="trending-description">
+            Browse {{ reviewer_count }} reviewer{% if reviewer_count != 1 %}s{% endif %}
+            from {{ org_count }} org{% if org_count != 1 %}s{% endif %}
+            and {{ contributor_count }} contributor{% if contributor_count != 1 %}s{% endif %}
+        </p>
         <div class="trending-grid">
             {% assign top_orgs = site.data.orgs.orgs | sort: "reviewers_count" | reverse | slice: 0,5 %}
             <div class="trending-column">


### PR DESCRIPTION
# User description
## Summary
- correct trending copy on homepage to avoid duplicated counts when pluralizing

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_68ac454b31b0832ba67ff10637194a55

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the homepage's trending-description to correctly pluralize counts for reviewers, organizations, and contributors, ensuring grammatical accuracy in the displayed text. Modifies the <code>index.html</code> template, which renders the main page content, to implement this improved pluralization logic.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Restore-emoji-stats-on...</td><td>August 25, 2025</td></tr>
<tr><td>nimrodkor</td><td>Better-search-function...</td><td>July 10, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/116?tool=ast>(Baz)</a>.