### PR TITLE
Run data generators on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,13 +31,17 @@ jobs:
         run: pip install pyyaml
       - name: Generate leaderboard
         run: python generate_leaderboard.py
-      - name: Commit leaderboard data
+      - name: Generate orgs data
+        run: python generate_orgs_data.py
+      - name: Generate crawler files
+        run: python generate_crawler_files.py
+      - name: Commit generated data
         run: |
           if [[ `git status --porcelain` ]]; then
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add _data/leaderboard.json assets/data/contributors.json
-            git commit -m "Update leaderboard [skip ci]"
+            git add _data/leaderboard.json assets/data/contributors.json _data/orgs.json robots.txt llms.txt
+            git commit -m "Update generated data [skip ci]"
             git push
           fi
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
# User description
## Summary
- run organization and crawler data generators during deployment
- commit refreshed leaderboard, org, and crawler data assets

## Testing
- `python generate_leaderboard.py`
- `python generate_orgs_data.py` *(fails: blocked while fetching org profile)*
- `python generate_crawler_files.py`

------
https://chatgpt.com/codex/tasks/task_b_68ac59362d1c832b9c7e0c771948ccea

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Integrate new data generation scripts for organization and crawler data into the GitHub Actions deployment workflow. Ensure the workflow commits the refreshed <code>_data/orgs.json</code>, <code>robots.txt</code>, and <code>llms.txt</code> assets, along with existing leaderboard data, back to the repository.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Consolidate-GitHub-Act...</td><td>July 28, 2025</td></tr>
<tr><td>nimrodkor</td><td>Fix-deployment</td><td>July 27, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/117?tool=ast>(Baz)</a>.