### PR TITLE
Persist organization slug in URL hash

### DIFF
--- a/orgs.html
+++ b/orgs.html
@@ -152,6 +152,7 @@ function applyProfile(row, data) {
 function openOrgDrawer(name) {
   const info = orgData.find(o => o.name === name);
   if (!info) return;
+  location.hash = encodeURIComponent(name);
   const drawer = document.getElementById('org-drawer');
   const content = document.getElementById('org-drawer-content');
   content.innerHTML = '';
@@ -254,6 +255,7 @@ function openOrgDrawer(name) {
 
 function closeOrgDrawer() {
   document.getElementById('org-drawer').classList.remove('open');
+  history.replaceState(null, '', window.location.pathname + window.location.search);
 }
 
 const orgTable = document.getElementById('org-table');
@@ -267,10 +269,19 @@ document.querySelectorAll('#org-table tbody tr').forEach(row => {
   });
 });
 
-const initialOrg = location.hash.slice(1);
+const initialOrg = decodeURIComponent(location.hash.slice(1));
 if (initialOrg) {
   openOrgDrawer(initialOrg);
 }
+
+window.addEventListener('hashchange', () => {
+  const current = decodeURIComponent(location.hash.slice(1));
+  if (current) {
+    openOrgDrawer(current);
+  } else {
+    closeOrgDrawer();
+  }
+});
 
 const filterInput = document.getElementById('org-filter');
 filterInput.addEventListener('input', () => {


### PR DESCRIPTION
## Summary
- Update org drawer to set and respond to URL hash
- Clear hash when closing org drawer
- Decode initial hash and handle hashchange for deep linking

## Testing
- `python -m py_compile generate_orgs_data.py`


------
https://chatgpt.com/codex/tasks/task_b_68b81ce2aa1c832b89985f245625e26e