### PR TITLE
fix: escape lobe-chat merge snippet

### DIFF
--- a/_reviewers/lobe-chat-configuration-merging-precedence.md
+++ b/_reviewers/lobe-chat-configuration-merging-precedence.md
@@ -21,6 +21,7 @@ When merging configuration objects, always preserve existing values and follow c
 **Examples:**
 
 ❌ **Problematic merging** - overwrites existing footerAction:
+{% raw %}
 ```tsx
 appearance={{
   ...appearance,
@@ -30,8 +31,10 @@ appearance={{
   }
 }}
 ```
+{% endraw %}
 
 ✅ **Proper conditional merging**:
+{% raw %}
 ```tsx
 appearance={{
   ...appearance,
@@ -41,6 +44,7 @@ appearance={{
   }
 }}
 ```
+{% endraw %}
 
 ❌ **Component-level merging**:
 ```tsx


### PR DESCRIPTION
# User description
## Summary
- prevent Liquid from parsing TSX examples by wrapping them in raw blocks

## Testing
- `bundle install`
- `bundle exec jekyll build` *(fails: Liquid syntax error in _reviewers/lobe-chat-css-utility-usage.md)*

------
https://chatgpt.com/codex/tasks/task_b_68b945d57978832ba3d7ecb47d57e16f

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Prevent <code>Liquid</code> from parsing <code>TSX</code> code examples by wrapping them in <code>raw</code> blocks within markdown files, ensuring code snippets are displayed correctly.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>internal-baz-ci-app[bot]</td><td>Add-31-awesome-reviewe...</td><td>September 03, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/122?tool=ast>(Baz)</a>.