### PR TITLE
fix: escape lobe-chat merge snippet

### DIFF
--- a/_reviewers/lobe-chat-configuration-merging-precedence.md
+++ b/_reviewers/lobe-chat-configuration-merging-precedence.md
@@ -21,6 +21,7 @@ When merging configuration objects, always preserve existing values and follow c
 **Examples:**
 
 ❌ **Problematic merging** - overwrites existing footerAction:
+{% raw %}
 ```tsx
 appearance={{
   ...appearance,
@@ -30,8 +31,10 @@ appearance={{
   }
 }}
 ```
+{% endraw %}
 
 ✅ **Proper conditional merging**:
+{% raw %}
 ```tsx
 appearance={{
   ...appearance,
@@ -41,6 +44,7 @@ appearance={{
   }
 }}
 ```
+{% endraw %}
 
 ❌ **Component-level merging**:
 ```tsx

--- a/_reviewers/lobe-chat-css-utility-usage.md
+++ b/_reviewers/lobe-chat-css-utility-usage.md
@@ -15,6 +15,7 @@ Use CSS utility functions and avoid complex inline calculations for better maint
 
 **Recommended patterns:**
 
+{% raw %}
 ```ts
 // ✅ Good: Use cx() for combining classes
 const { styles, cx } = useStyles();
@@ -34,5 +35,6 @@ const extraTitle = css`
 // ❌ Avoid: Complex CSS calculations that are fragile
 style={{ maxHeight: `calc(75vh - 56px - 13px - ${gap}px)` }}
 ```
+{% endraw %}
 
 Avoid overly complex CSS calculations that depend on magic numbers, as they become fragile when layouts change. Consider using CSS inheritance properties or more robust layout solutions instead.


### PR DESCRIPTION
# User description
## Summary
- prevent Liquid from parsing TSX examples by wrapping them in raw blocks
- wrap lobe-chat CSS utility snippet in raw block to avoid Liquid parsing errors

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_b_68b945d57978832ba3d7ecb47d57e16f

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Wrap code snippets in <code>_reviewers/lobe-chat-configuration-merging-precedence.md</code> and <code>_reviewers/lobe-chat-css-utility-usage.md</code> with Liquid <code>raw</code> blocks; this prevents Liquid from incorrectly parsing example TSX and TypeScript code, ensuring accurate display of documentation.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>fix-escape-lobe-chat-m...</td><td>September 04, 2025</td></tr>
<tr><td>internal-baz-ci-app[bot]</td><td>Add-31-awesome-reviewe...</td><td>September 03, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/123?tool=ast>(Baz)</a>.