### PR TITLE
Add skill tag and language filters

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -83,6 +83,9 @@
 
 
 <script>
+    let tagFilter;
+    let languageFilter;
+
     // Multi-select filter functionality
     class MultiSelect {
         constructor(containerId, options) {
@@ -258,11 +261,19 @@
     function updateUrlParams() {
         const searchInput = document.getElementById('search');
         const searchTerm = searchInput ? searchInput.value : '';
+        const selectedTags = tagFilter ? tagFilter.getSelected() : [];
+        const selectedLanguages = languageFilter ? languageFilter.getSelected() : [];
 
         const params = new URLSearchParams();
-        
+
         if (searchTerm) {
             params.set('search', searchTerm);
+        }
+        if (selectedTags.length > 0) {
+            params.set('tags', selectedTags.join(','));
+        }
+        if (selectedLanguages.length > 0) {
+            params.set('languages', selectedLanguages.join(','));
         }
 
         const newUrl = params.toString() ? `${window.location.pathname}?${params.toString()}` : window.location.pathname;
@@ -278,6 +289,47 @@
             if (searchInput) searchInput.value = searchTerm;
         }
 
+        const tags = (params.get('tags') || '')
+            .split(',')
+            .map(value => value.trim())
+            .filter(Boolean);
+        const languages = (params.get('languages') || '')
+            .split(',')
+            .map(value => value.trim())
+            .filter(Boolean);
+
+        if (tagFilter) {
+            tagFilter.selectedValues = tagFilter.options.filter(option => tags.includes(option));
+            tagFilter.render();
+            tagFilter.attachEvents();
+        }
+
+        if (languageFilter) {
+            languageFilter.selectedValues = languageFilter.options.filter(option => languages.includes(option));
+            languageFilter.render();
+            languageFilter.attachEvents();
+        }
+    }
+
+    function collectUniqueCardValues(datasetKey) {
+        return Array.from(document.querySelectorAll('.reviewer-card'))
+            .map(card => (card.dataset[datasetKey] || '').trim())
+            .filter(Boolean)
+            .filter((value, index, values) => values.indexOf(value) === index)
+            .sort((a, b) => a.localeCompare(b));
+    }
+
+    function initReviewerFilters() {
+        const tagContainer = document.getElementById('tag-filter');
+        const languageContainer = document.getElementById('language-filter');
+
+        if (tagContainer) {
+            tagFilter = new MultiSelect('tag-filter', collectUniqueCardValues('category'));
+        }
+
+        if (languageContainer) {
+            languageFilter = new MultiSelect('language-filter', collectUniqueCardValues('language'));
+        }
     }
 
     function initFeedFilters() {
@@ -331,10 +383,12 @@
     function filterReviewers() {
         const searchInput = document.getElementById('search');
         const searchTerm = searchInput ? searchInput.value.toLowerCase() : '';
+        const selectedTags = tagFilter ? tagFilter.getSelected() : [];
+        const selectedLanguages = languageFilter ? languageFilter.getSelected() : [];
 
         const cards = document.querySelectorAll('.reviewer-card');
         let visibleCount = 0;
-        const initialView = searchTerm === '';
+        const initialView = searchTerm === '' && selectedTags.length === 0 && selectedLanguages.length === 0;
 
         cards.forEach(card => {
             const titleEl = card.querySelector('.reviewer-title');
@@ -352,8 +406,10 @@
                 repo.toLowerCase().includes(searchTerm) ||
                 category.toLowerCase().includes(searchTerm) ||
                 language.toLowerCase().includes(searchTerm);
-                
-            if (matchesSearch) {
+            const matchesTag = selectedTags.length === 0 || selectedTags.includes(category);
+            const matchesLanguage = selectedLanguages.length === 0 || selectedLanguages.includes(language);
+
+            if (matchesSearch && matchesTag && matchesLanguage) {
                 if (
                     initialView &&
                     card.classList.contains('extra-reviewer') &&
@@ -396,10 +452,12 @@
     function clearFilters() {
         const searchInput = document.getElementById('search');
         if (searchInput) searchInput.value = '';
-        
+        if (tagFilter) tagFilter.clear();
+        if (languageFilter) languageFilter.clear();
+
         // Clear URL parameters
         history.replaceState(null, '', window.location.pathname);
-        
+
         filterReviewers();
     }
 
@@ -442,6 +500,8 @@
 
         if (document.getElementById('search')) {
             const searchInput = document.getElementById('search');
+
+            initReviewerFilters();
 
             if (searchInput) searchInput.addEventListener('input', filterReviewers);
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1196,6 +1196,10 @@ h6 {
     gap: 0.375rem;
 }
 
+.filter-group:first-child {
+    flex: 1 1 240px;
+}
+
 .filter-select {
     background: var(--bg-secondary);
     border: 1px solid var(--border);
@@ -1210,6 +1214,7 @@ h6 {
 .multi-select-container {
     position: relative;
     min-width: 200px;
+    width: 100%;
 }
 
 .multi-select-trigger {
@@ -1336,6 +1341,7 @@ h6 {
     border-radius: 0;
     font-size: 0.875rem;
     min-width: 200px;
+    width: 100%;
     box-sizing: border-box;
 }
 

--- a/index.html
+++ b/index.html
@@ -33,6 +33,12 @@ description: Browse and filter system prompts created from real-world code revie
       <div class="filter-group">
         <input type="text" id="search" class="search-input" placeholder="Search skills...">
       </div>
+      <div class="filter-group">
+        <div id="tag-filter" class="multi-select-container" data-placeholder="Filter by tag" aria-label="Filter skills by tag"></div>
+      </div>
+      <div class="filter-group">
+        <div id="language-filter" class="multi-select-container" data-placeholder="Filter by language" aria-label="Filter skills by language"></div>
+      </div>
       <button class="clear-filters btn btn--ghost" onclick="clearFilters()" title="Clear filters" aria-label="Clear filters">⟳</button>
     </div>
   </div>


### PR DESCRIPTION
# User description
### Motivation
- Improve discoverability by allowing users to filter the skills library by reviewer metadata (tag/label and language) rather than relying on free-text search alone.
- Leverage existing reviewer metadata on each card (`data-category` / `data-language`) and the existing `MultiSelect` component to avoid a large UI rewrite.

### Description
- Add two multi-select filter controls to the filter bar in `index.html` with IDs `tag-filter` and `language-filter` to allow selecting tags and languages.
- Extend the inline site JS in `_layouts/default.html` to instantiate `tagFilter` and `languageFilter`, populate their options from card metadata (`collectUniqueCardValues`), and wire selection state into `filterReviewers` so selections are combined with the existing free-text search.
- Persist active filters in the URL using `tags` and `languages` query params via `updateUrlParams` and restore them on load with `loadFiltersFromUrl`.
- Update styling in `assets/css/main.scss` to make the new controls and the search input layout responsive and consistent with the existing filter bar.

### Testing
- `node --check /tmp/default_inline.js` succeeded to validate the modified inline JavaScript syntax.
- `bundle exec jekyll build` could not be run in this environment because `jekyll` is not installed, so a full site build was not performed (failed to run).
- `bundle install` failed with a `403 Forbidden` from `rubygems.org` in this environment, preventing installation of build dependencies and blocking a local Jekyll build.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ba921598f4832bb68432c39a67714b)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add new <code>MultiSelect</code> controls for tags and languages to the filter bar and wire them into the inline <code>MultiSelect</code> logic so selections combine with existing search filtering and URL syncing. Persist filter metadata state via the inline loader by collecting reviewer card tags/languages and restoring the <code>tagFilter</code> and <code>languageFilter</code> controls on load.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/baz-scm/awesome-reviewers/203?tool=ast&topic=Filter+bar+UI>Filter bar UI</a>
        </td><td>Add responsive filter-bar markup and styling so the new tag and language multi-select controls sit beside the search input without disrupting layout.<details><summary>Modified files (2)</summary><ul><li>assets/css/main.scss</li>
<li>index.html</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Make-repo-label-open-s...</td><td>February 09, 2026</td></tr>
<tr><td>nimrod@baz.co</td><td>Better-search-function...</td><td>July 10, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/baz-scm/awesome-reviewers/203?tool=ast&topic=Reviewer+filters>Reviewer filters</a>
        </td><td>Extend <code>MultiSelect</code>-based filtering by initializing <code>tagFilter</code> and <code>languageFilter</code>, combining their selections with the search-term logic, and syncing state through <code>filterReviewers</code>, <code>updateUrlParams</code>, and URL-based reload handling.<details><summary>Modified files (1)</summary><ul><li>_layouts/default.html</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Remove-dead-reviewer-l...</td><td>February 08, 2026</td></tr>
<tr><td>nimrod@baz.co</td><td>Better-search-function...</td><td>July 10, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/203?tool=ast>(Baz)</a>.