### PR TITLE
Fix reviewer prompt code contrast rendering

### DIFF
--- a/assets/prism/prism.css
+++ b/assets/prism/prism.css
@@ -138,3 +138,51 @@ pre[class*="language-"] {
 .token.entity {
 	cursor: help;
 }
+
+/* Awesome Reviewers overrides: keep reviewer prompt code contrast readable */
+.reviewer-prompt pre[class*="language-"],
+.reviewer-prompt :not(pre) > code[class*="language-"] {
+	background: var(--bg-primary);
+	border-color: var(--border);
+}
+
+.reviewer-prompt code[class*="language-"],
+.reviewer-prompt pre[class*="language-"] {
+	color: var(--text-primary);
+	text-shadow: none;
+}
+
+.reviewer-prompt .token.comment,
+.reviewer-prompt .token.prolog,
+.reviewer-prompt .token.doctype,
+.reviewer-prompt .token.cdata,
+.reviewer-prompt .token.punctuation,
+.reviewer-prompt .token.property,
+.reviewer-prompt .token.tag,
+.reviewer-prompt .token.boolean,
+.reviewer-prompt .token.number,
+.reviewer-prompt .token.constant,
+.reviewer-prompt .token.symbol,
+.reviewer-prompt .token.deleted,
+.reviewer-prompt .token.selector,
+.reviewer-prompt .token.attr-name,
+.reviewer-prompt .token.string,
+.reviewer-prompt .token.char,
+.reviewer-prompt .token.builtin,
+.reviewer-prompt .token.inserted,
+.reviewer-prompt .token.operator,
+.reviewer-prompt .token.entity,
+.reviewer-prompt .token.url,
+.reviewer-prompt .language-css .token.string,
+.reviewer-prompt .style .token.string,
+.reviewer-prompt .token.atrule,
+.reviewer-prompt .token.attr-value,
+.reviewer-prompt .token.keyword,
+.reviewer-prompt .token.function,
+.reviewer-prompt .token.class-name,
+.reviewer-prompt .token.regex,
+.reviewer-prompt .token.important,
+.reviewer-prompt .token.variable {
+	color: var(--text-primary);
+	background: transparent;
+}


### PR DESCRIPTION
# User description
### Motivation
- Code shown inside reviewer prompt cards was rendering with low contrast in some contexts (notably iOS/social embeds) due to Prism's default light-gray code background and token fills, making text hard to read.
- The change aims to keep prompt content readable by forcing code blocks and tokens inside prompt containers to use the site theme colors.

### Description
- Added scoped Prism overrides to `assets/prism/prism.css` under a `.reviewer-prompt` selector to avoid altering global Prism styling.
- Set code block and inline code backgrounds to `var(--bg-primary)` and border colors to `var(--border)` so they follow the active theme.
- Normalized token colors inside `.reviewer-prompt` to `var(--text-primary)` and removed token background fills to ensure stable, high-contrast rendering.

### Testing
- Ran `git diff -- assets/prism/prism.css` to inspect the CSS changes and verified the overrides are scoped and present, which succeeded. 
- Committed the change with `git commit -m "Fix reviewer prompt code contrast on iOS/social previews"`, which succeeded. 
- Inspected the resulting file with `nl -ba assets/prism/prism.css | tail -n 70` to confirm the new rules appear at the end of the file, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fcb8556b48832b8fe4aa30d65e24ea)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Align Prism styling so reviewer prompt cards rely on the site theme to ensure readable code using the same background, border, and text colors as the rest of the prompt UI. Prevent Prism token colors and backgrounds from reintroducing low-contrast fills by normalizing them to the primary text color within reviewer prompt containers.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Fix reviewer prompt co...</td><td>May 07, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/205?tool=ast>(Baz)</a>.