### PR TITLE
Add /cyber/ landing page with `cyber.md` content and styling

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -4452,3 +4452,71 @@ h2 .stat-value {
         margin-left: auto;
     }
 }
+
+/* cyber.md page */
+.cyber-page {
+  background: #050608;
+  color: rgba(255,255,255,0.9);
+}
+
+.cyber-container {
+  width: min(920px, 92vw);
+  margin: 0 auto;
+}
+
+.cyber-hero,
+.cyber-section {
+  padding: clamp(3rem, 7vw, 6rem) 0;
+  border-top: 1px solid rgba(255,255,255,0.08);
+}
+
+.cyber-hero { border-top: 0; }
+.cyber-section--alt { background: #070a10; }
+
+.cyber-kicker {
+  display: inline-block;
+  padding: 0.35rem 0.75rem;
+  border: 1px solid rgba(107,155,255,0.45);
+  border-radius: 999px;
+  color: rgba(192,214,255,0.95);
+  font-size: 0.84rem;
+  letter-spacing: 0.04em;
+  margin-bottom: 1rem;
+}
+
+.cyber-page h1 {
+  font-size: clamp(2.2rem, 7vw, 4rem);
+  margin-bottom: 1rem;
+}
+.cyber-page h2 {
+  font-size: clamp(1.7rem, 4vw, 2.4rem);
+  margin-bottom: 1rem;
+}
+.cyber-page h3 {
+  margin: 1.7rem 0 0.7rem;
+}
+.cyber-page p,
+.cyber-page li {
+  color: rgba(255,255,255,0.8);
+  font-size: 1.08rem;
+  line-height: 1.7;
+}
+.cyber-page p + p { margin-top: 0.8rem; }
+.cyber-page ul,
+.cyber-page ol { margin: 1rem 0 0 1.4rem; }
+.cyber-page li + li { margin-top: 0.35rem; }
+.cyber-lead { font-size: 1.35rem !important; color: rgba(235,242,255,0.95) !important; }
+.cyber-highlight { font-weight: 600; color: #d9e6ff !important; }
+
+.cyber-page pre {
+  margin-top: 1.2rem;
+  padding: 1.2rem;
+  border-radius: 12px;
+  border: 1px solid rgba(160,190,255,0.3);
+  background: #05070d;
+  overflow-x: auto;
+}
+.cyber-page code {
+  font-family: var(--font-family-mono);
+  color: #d2e2ff;
+}

--- a/cyber.html
+++ b/cyber.html
@@ -1,0 +1,172 @@
+---
+layout: default
+title: cyber.md
+description: Versioned security posture that agents can read, diff, and apply during normal development.
+permalink: /cyber/
+---
+
+<main class="cyber-page">
+  <section class="cyber-hero">
+    <div class="cyber-container">
+      <p class="cyber-kicker">cyber.md</p>
+      <h1>AI-native posture that speaks agent.</h1>
+      <p class="cyber-lead">Developers and coding agents are now generating more code than security teams can realistically review by hand.</p>
+      <p>The old security workflow assumed humans opened pull requests, humans remembered the threat model, humans knew the dangerous parts of the codebase, and humans slowly reviewed everything before deployment.</p>
+      <p>That assumption no longer holds.</p>
+      <p>Coding agents are refactoring auth flows, changing infrastructure logic, updating dependencies, modifying API boundaries, and introducing new integrations independently. At the same time, attacker-operated agents are scaling reconnaissance, fuzzing, and exploit discovery faster than traditional AppSec processes can react.</p>
+      <p>We think repositories need a new primitive:</p>
+      <p class="cyber-highlight">Versioned security posture that agents can read, diff, and apply during normal development.</p>
+      <p>We’re calling it <code>cyber.md</code>.</p>
+    </div>
+  </section>
+
+  <section class="cyber-section">
+    <div class="cyber-container">
+      <h2>What is cyber.md?</h2>
+      <p><code>cyber.md</code> is an open Markdown convention for describing the defensive security posture of a repository in a format that coding agents can understand during development.</p>
+      <p>The file itself is intentionally simple. It defines:</p>
+      <ul>
+        <li>protected assets</li><li>trust boundaries</li><li>security invariants</li><li>high-risk surfaces</li><li>preferred defensive patterns</li><li>required tests</li><li>review triggers</li><li>ownership expectations</li>
+      </ul>
+      <p>The goal is not to teach agents how to attack the system.</p>
+      <p>The goal is to help them avoid weakening it while they write code.</p>
+    </div>
+  </section>
+
+  <section class="cyber-section cyber-section--alt">
+    <div class="cyber-container">
+      <h2>Why Markdown?</h2>
+      <p>Agents already understand Markdown extremely well.</p>
+      <p>Modern coding tools routinely consume repository-local files like:</p>
+      <pre><code>README.md
+CONTRIBUTING.md
+AGENTS.md</code></pre>
+      <p><code>cyber.md</code> extends the same idea to security posture. A repository should expose enough durable defensive context so that agents can preserve important security properties during implementation, review, and refactoring.</p>
+    </div>
+  </section>
+
+  <section class="cyber-section">
+    <div class="cyber-container">
+      <h2>A posture file, not a vulnerability report</h2>
+      <p><code>cyber.md</code> is not:</p>
+      <ul>
+        <li>a pentest report</li><li>a risk register</li><li>an exploit notebook</li><li>a collection of bypass paths</li><li>a customer incident archive</li>
+      </ul>
+      <p>The checked-in version should contain safe defensive guidance only. Commit the posture, not the exploit.</p>
+    </div>
+  </section>
+
+  <section class="cyber-section cyber-section--alt">
+    <div class="cyber-container">
+      <h2>Example</h2>
+      <pre><code># cyber.md
+
+## Protected Assets
+- Customer API tokens
+- Tenant-scoped billing data
+- Deployment credentials
+
+## Trust Boundaries
+### Public API Boundary
+Invariant:
+All external input must be authenticated, validated, and tenant-scoped before database access.
+
+Required Tests:
+- auth bypass regression test
+- tenant isolation test
+- rate limit coverage
+
+## Sensitive Modules
+### /services/auth
+Additional Review Required:
+- token generation
+- session handling
+- permission checks
+
+Preferred Patterns:
+- short-lived tokens
+- centralized authorization helpers
+- no inline permission logic</code></pre>
+    </div>
+  </section>
+
+  <section class="cyber-section">
+    <div class="cyber-container">
+      <h2>Not just for security review</h2>
+      <p>Inside an agent-native workflow, <code>cyber.md</code> becomes a lightweight defensive context layer.</p>
+      <ol>
+        <li>inspect the task</li><li>identify touched files</li><li>classify relevant risk areas</li><li>retrieve posture guidance</li><li>inject a minimal advice packet into the coding session</li>
+      </ol>
+      <p>Not a giant scan report. Not a 200-page policy document. Just relevant posture at the exact moment code is being written.</p>
+    </div>
+  </section>
+
+  <section class="cyber-section cyber-section--alt">
+    <div class="cyber-container">
+      <h2>Under the hood</h2>
+      <h3>1. Posture generation</h3>
+      <p>A generator scans the repository and produces or updates <code>cyber.md</code>.</p>
+      <h3>2. Context retrieval</h3>
+      <p>During development, a posture layer reads <code>cyber.md</code> via hooks, brokers, CI, bots, or IDE extensions.</p>
+      <h3>3. Task-specific injection</h3>
+      <pre><code>Developer requests code change
+        ↓
+Task + files classified
+        ↓
+Relevant posture selected
+        ↓
+Sensitive context brokered if needed
+        ↓
+Small advice packet injected
+        ↓
+Agent writes product code
+        ↓
+Diff checked against invariants</code></pre>
+    </div>
+  </section>
+
+  <section class="cyber-section">
+    <div class="cyber-container">
+      <h2>Attackers can read Markdown too</h2>
+      <p>A repository-visible posture file can expose sensitive surfaces and trust assumptions, so <code>cyber.md</code> must be treated as part of the trusted development surface.</p>
+      <p>It should never contain secrets, exploit recipes, bypass instructions, sensitive topology, customer-specific incidents, or offensive tradecraft.</p>
+
+      <h2>Instruction poisoning is real</h2>
+      <p>Files like <code>AGENTS.md</code> and <code>cyber.md</code> should be code reviewed, ownership protected, and diffed carefully.</p>
+
+      <h2>Optional: split posture model</h2>
+      <p><strong>Public posture:</strong> Safe defensive guidance stored in Git.</p>
+      <p><strong>Private posture:</strong> Sensitive context stored behind a broker and returned minimally per task.</p>
+    </div>
+  </section>
+
+  <section class="cyber-section cyber-section--alt">
+    <div class="cyber-container">
+      <h2>What should go inside cyber.md?</h2>
+      <h3>Scope</h3>
+      <ul><li>repository</li><li>services</li><li>frameworks</li><li>languages</li><li>sensitivity level</li></ul>
+      <h3>Protected assets</h3>
+      <ul><li>credentials</li><li>identities</li><li>admin privileges</li><li>tenant data</li><li>integration secrets</li></ul>
+      <h3>Trust boundaries</h3>
+      <ul><li>invariant</li><li>ownership</li><li>validation expectations</li><li>required controls</li><li>review triggers</li></ul>
+      <h3>Security guidance</h3>
+      <ul><li>authorization expectations</li><li>tenant isolation rules</li><li>secrets handling</li><li>dependency hygiene</li><li>logging constraints</li><li>secure defaults</li><li>encryption requirements</li></ul>
+      <h3>Required tests</h3>
+      <ul><li>auth regressions</li><li>permission coverage</li><li>tenant isolation</li><li>input validation</li><li>audit logging</li><li>rate limiting</li></ul>
+    </div>
+  </section>
+
+  <section class="cyber-section">
+    <div class="cyber-container">
+      <h2>Why this matters</h2>
+      <p><code>cyber.md</code> shifts posture guidance earlier: into the exact moment an agent is about to write code.</p>
+      <ul><li>invariants survive refactors</li><li>safer defaults spread naturally</li><li>regression tests accumulate</li><li>risky patterns get corrected earlier</li><li>agents become less likely to weaken critical paths</li></ul>
+
+      <h2>What’s next?</h2>
+      <ul><li>Posture diffs</li><li>Better retrieval</li><li>Private posture brokers</li><li>Security-aware test generation</li><li>Posture maturity scoring</li></ul>
+
+      <h2>Getting started</h2>
+      <p>Create <code>cyber.md</code> at the repository root. Start small and connect it to IDE hooks, pull request bots, CI checks, agent context injection, or MCP brokers.</p>
+    </div>
+  </section>
+</main>


### PR DESCRIPTION
# User description
### Motivation
- Provide an agent-friendly, documented security posture primitive (`cyber.md`) as a first-class landing page on the site. 
- Surface durable, repo-local defensive guidance that coding agents and workflows can consume during development. 
- Match the visual and typographic style of the existing site so the new page integrates with the current documentation aesthetic.

### Description
- Added a new Jekyll page `cyber.html` with `permalink: /cyber/` that contains the full `cyber.md` narrative broken into hero, content sections, examples, and code/preformatted blocks. 
- Extended `assets/css/main.scss` with `.cyber-page` styles and related rules for hero layout, alternating section backgrounds, typography, callouts, and code block presentation. 
- Kept the page using the existing site layout (`layout: default`) and existing typography variables so it inherits the site’s dark theme and font system. 
- Structured content for easy copying into a repository-level `cyber.md` and for selective retrieval by tooling (code blocks, lists, and short guidance sections).

### Testing
- Attempted to run `bundle exec jekyll build` to verify the site build, but the command failed in this environment because the `jekyll` executable is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a004f41a4a0832ba864d8f3ce084c88)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Ship a <code>cyber.html</code> landing page built on the default layout to serve the <code>cyber.md</code> posture narrative via hero, content, and guidance sections tailored to agents. Extend <code>assets/css/main.scss</code> with <code>.cyber-page</code> styling so the new page inherits the dark theme, typography variables, and callout/code treatments of the existing site.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/baz-scm/awesome-reviewers/206?tool=ast&topic=cyber+landing>cyber landing</a>
        </td><td>Lay out the <code>cyber.html</code> landing page with hero, alternating sections, examples, and attacker guidance so the repository’s posture guidance reads like a first-class agent-friendly document.<details><summary>Modified files (1)</summary><ul><li>cyber.html</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Add new cyber.md landi...</td><td>May 10, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/baz-scm/awesome-reviewers/206?tool=ast&topic=cyber+styling>cyber styling</a>
        </td><td>Style the <code>cyber.html</code> experience by adding <code>.cyber-page</code> and related selectors in <code>assets/css/main.scss</code> to match the site’s dark theme, typography, and code/callout presentation.<details><summary>Modified files (1)</summary><ul><li>assets/css/main.scss</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Add new cyber.md landi...</td><td>May 10, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/206?tool=ast>(Baz)</a>.