### PR TITLE
Add Cyber filter for security reviewers

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -435,6 +435,32 @@
         
         // Update URL parameters
         updateUrlParams();
+        syncCyberFilterState();
+    }
+
+    function syncCyberFilterState() {
+        const cyberFilterButton = document.getElementById('cyber-filter');
+        if (!cyberFilterButton || !tagFilter) return;
+
+        const hasSecurityTag = tagFilter.getSelected().includes('Security');
+        cyberFilterButton.classList.toggle('is-active', hasSecurityTag);
+        cyberFilterButton.setAttribute('aria-pressed', hasSecurityTag ? 'true' : 'false');
+    }
+
+    function initCyberFilter() {
+        const cyberFilterButton = document.getElementById('cyber-filter');
+        if (!cyberFilterButton || !tagFilter) return;
+
+        cyberFilterButton.addEventListener('click', () => {
+            const hasSecurityTag = tagFilter.getSelected().includes('Security');
+            if (hasSecurityTag) {
+                tagFilter.removeTag('Security');
+            } else if (tagFilter.options.includes('Security')) {
+                tagFilter.addTag('Security');
+            }
+        });
+
+        syncCyberFilterState();
     }
 
     function updateReviewerCount(visible, total) {
@@ -502,6 +528,7 @@
             const searchInput = document.getElementById('search');
 
             initReviewerFilters();
+            initCyberFilter();
 
             if (searchInput) searchInput.addEventListener('input', filterReviewers);
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1361,6 +1361,12 @@ h6 {
     line-height: 1;
 }
 
+#cyber-filter.is-active {
+    background: var(--accent-soft);
+    color: var(--accent-strong);
+    border-color: color-mix(in srgb, var(--accent) 35%, transparent);
+}
+
 /* Main content and cards */
 .main-content {
     padding: 1rem 0;

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@ description: Browse and filter system prompts created from real-world code revie
       <div class="filter-group">
         <div id="language-filter" class="multi-select-container" data-placeholder="Filter by language" aria-label="Filter skills by language"></div>
       </div>
+      <button id="cyber-filter" class="btn btn--ghost" type="button" aria-pressed="false" title="Filter to security skills only">Cyber</button>
       <button class="clear-filters btn btn--ghost" onclick="clearFilters()" title="Clear filters" aria-label="Clear filters">⟳</button>
     </div>
   </div>


### PR DESCRIPTION
# User description
### Motivation
- Provide a first-class, one-click filter so users can quickly view security-focused skills (labelled `Security`) from the main filter bar and keep the UI state consistent across other filters.

### Description
- Add a `Cyber` button to the homepage filter bar (`index.html`) to serve as a dedicated security filter toggle.
- Implement `initCyberFilter()` and `syncCyberFilterState()` in the shared layout script (`_layouts/default.html`) to toggle the `Security` tag via the existing `tagFilter` API and keep the button `aria-pressed`/active state synchronized with other filter changes.
- Wire the new behavior into `filterReviewers()` and DOM initialization so the button reflects changes from URL/tag/language interactions, and add active-state styling for `#cyber-filter.is-active` in `assets/css/main.scss`.

### Testing
- Attempted a site build with `bundle exec jekyll build --quiet`, which failed in this environment because `jekyll` is not installed (Bundler reported `command not found: jekyll`).
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0061264380832b9f49a6235e5d9ea4)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add a Cyber button to the homepage filter bar and wire it into the layout DOM initialization to expose the security-focused <code>Security</code> tag as a dedicated toggle. Implement <code>initCyberFilter</code>/<code>syncCyberFilterState</code> in the shared layout script and refresh the button styling so it stays synchronized with other filters and shows the active state.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/baz-scm/awesome-reviewers/208?tool=ast&topic=Cyber+filter+behavior>Cyber filter behavior</a>
        </td><td>Connect the Cyber filter button to <code>tagFilter</code> so clicks add/remove the <code>Security</code> tag, call <code>syncCyberFilterState</code> from <code>filterReviewers</code>/URL updates, and keep the button’s <code>aria-pressed</code> and active class aligned with any filter changes.<details><summary>Modified files (2)</summary><ul><li>_layouts/default.html</li>
<li>index.html</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/baz-scm/awesome-reviewers/208?tool=ast&topic=Cyber+button+styling>Cyber button styling</a>
        </td><td>Style the Cyber button’s active state with the accent colors defined in the main stylesheet so it visually matches other filters when activated.<details><summary>Modified files (1)</summary><ul><li>assets/css/main.scss</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/208?tool=ast>(Baz)</a>.