### PR TITLE
Deprecate cyber filter control

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -435,50 +435,6 @@
         
         // Update URL parameters
         updateUrlParams();
-        syncCyberFilterState();
-    }
-
-    function getSecurityTagOption() {
-        if (!tagFilter) return null;
-
-        return tagFilter.options.find(option => option.trim().toLowerCase() === 'security') || null;
-    }
-
-    function syncCyberFilterState() {
-        const cyberFilterButton = document.getElementById('cyber-filter');
-        if (!cyberFilterButton || !tagFilter) return;
-
-        const securityTag = getSecurityTagOption();
-        const selectedTags = tagFilter
-            .getSelected()
-            .map(tag => tag.trim().toLowerCase());
-        const hasSecurityTag =
-            !!securityTag && selectedTags.includes(securityTag.toLowerCase());
-
-        cyberFilterButton.classList.toggle('is-active', hasSecurityTag);
-        cyberFilterButton.setAttribute('aria-pressed', hasSecurityTag ? 'true' : 'false');
-    }
-
-    function initCyberFilter() {
-        const cyberFilterButton = document.getElementById('cyber-filter');
-        if (!cyberFilterButton || !tagFilter) return;
-
-        cyberFilterButton.addEventListener('click', () => {
-            const securityTag = getSecurityTagOption();
-            if (!securityTag) return;
-
-            const hasSecurityTag = tagFilter
-                .getSelected()
-                .some(tag => tag.trim().toLowerCase() === securityTag.toLowerCase());
-
-            if (hasSecurityTag) {
-                tagFilter.removeTag(securityTag);
-            } else {
-                tagFilter.addTag(securityTag);
-            }
-        });
-
-        syncCyberFilterState();
     }
 
     function updateReviewerCount(visible, total) {
@@ -546,7 +502,6 @@
             const searchInput = document.getElementById('search');
 
             initReviewerFilters();
-            initCyberFilter();
 
             if (searchInput) searchInput.addEventListener('input', filterReviewers);
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1362,16 +1362,6 @@ h6 {
 }
 
 
-#cyber-filter {
-    border-color: #fff;
-}
-
-#cyber-filter.is-active {
-    background: var(--accent-soft);
-    color: var(--accent-strong);
-    border-color: color-mix(in srgb, var(--accent) 35%, transparent);
-}
-
 /* Main content and cards */
 .main-content {
     padding: 1rem 0;

--- a/index.html
+++ b/index.html
@@ -39,7 +39,6 @@ description: Browse and filter system prompts created from real-world code revie
       <div class="filter-group">
         <div id="language-filter" class="multi-select-container" data-placeholder="Filter by language" aria-label="Filter skills by language"></div>
       </div>
-      <button id="cyber-filter" class="btn btn--ghost" type="button" aria-pressed="false" title="Filter to security skills only">Cyber</button>
       <button class="clear-filters btn btn--ghost" onclick="clearFilters()" title="Clear filters" aria-label="Clear filters">⟳</button>
     </div>
   </div>


### PR DESCRIPTION
# User description
### Motivation
- The dedicated `Cyber` quick-filter button and its wiring are no longer desired and should be removed to simplify the filters UI and avoid maintaining special-case code.
- Removing the feature also eliminates associated JavaScript state-sync logic that only applied to that control.
- The CSS rules specific to the deprecated control are obsolete and can be removed to avoid dead styles.

### Description
- Removed the `Cyber` filter button from the filter controls in `index.html` by deleting the `<button id="cyber-filter">` element.
- Deleted the cyber-specific JavaScript helper functions and calls from `_layouts/default.html`, including `getSecurityTagOption`, `syncCyberFilterState`, `initCyberFilter`, and the calls to `syncCyberFilterState()` and `initCyberFilter()`.
- Removed the `#cyber-filter` and `#cyber-filter.is-active` style rules from `assets/css/main.scss`.
- Kept the general filter initialization and URL/state update flows intact to preserve existing behavior for tags, language, and search filters.

### Testing
- Ran a repository search with `rg -n "cyber"` to locate usages and confirm remaining references are removed, which succeeded.
- Reviewed the changes with `git diff -- _layouts/default.html index.html assets/css/main.scss` to validate the exact removals, which succeeded.
- Staged and committed the changes with `git add` and `git commit -m "Deprecate cyber filter control"`, and the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a00c15d6884832bb279c044a46ebd9f)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Streamline the Filter UI controls by removing the dedicated Cyber quick-filter button while leaving the remaining language, tag, and search filters intact. Simplify the layout script and styles by deleting the Cyber-specific helpers and CSS, eliminating the state-sync logic tied to that button.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/baz-scm/awesome-reviewers/211?tool=ast&topic=Cyber+filter+removal>Cyber filter removal</a>
        </td><td>Remove the Cyber quick-filter button, its event wiring, and helper functions so only the general tag, language, and search controls handle filter state.<details><summary>Modified files (2)</summary><ul><li>_layouts/default.html</li>
<li>index.html</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Deprecate cyber filter...</td><td>May 10, 2026</td></tr>
<tr><td>nimrod@baz.co</td><td>Better search function...</td><td>July 10, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/baz-scm/awesome-reviewers/211?tool=ast&topic=Cyber+style+cleanup>Cyber style cleanup</a>
        </td><td>Delete the obsolete <code>#cyber-filter</code> rules so CSS only covers active UI elements.<details><summary>Modified files (1)</summary><ul><li>assets/css/main.scss</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>guyeisenkot</td><td>Deprecate cyber filter...</td><td>May 10, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/baz-scm/awesome-reviewers/211?tool=ast>(Baz)</a>.