### PR TITLE
Replace counters with embed guide section

### DIFF
--- a/assets/css/site.scss
+++ b/assets/css/site.scss
@@ -110,16 +110,40 @@ code, kbd, pre { font-family: var(--mono); }
 .intro__lead { max-width: 62ch; margin-top: 10px; color: var(--muted); }
 .intro__lead strong { color: var(--text); font-weight: 600; }
 
-.counters {
-  display: flex;
+.embed-guide {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
   gap: 24px;
-  margin-top: 20px;
-  font-family: var(--mono);
-  font-size: 0.78rem;
-  color: var(--faint);
-  flex-wrap: wrap;
+  margin-top: 24px;
 }
-.counters b { display: block; font-size: 1.05rem; color: var(--text); font-weight: 600; }
+
+.embed-guide__section {
+  padding: 16px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+.embed-guide__section h3 {
+  font-size: 0.95rem;
+  margin-bottom: 8px;
+}
+
+.embed-guide__section p {
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.embed-guide__section code {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 2px 6px;
+  font-size: 0.8rem;
+  font-family: var(--mono);
+}
 
 .section { padding: 32px 0 0; }
 .section__head {

--- a/index.html
+++ b/index.html
@@ -17,11 +17,19 @@ description: Expert engineering instructions for AI and infrastructure domains, 
       Each one is plain markdown: <strong>copy it here, or fetch it as raw text</strong> and load it
       into an agent, harness or context broker.
     </p>
-    <div class="counters">
-      <div><b>{{ total }}</b> instructions</div>
-      <div><b>{{ stats.domains | size }}</b> domains</div>
-      <div><b>{{ site.data.sources.sources | size }}</b> repositories</div>
-      <div><b><time data-date="{{ stats.updated }}">{{ stats.updated }}</time></b> last update</div>
+    <div class="embed-guide">
+      <div class="embed-guide__section">
+        <h3>Use in an AI agent</h3>
+        <p>Paste an instruction directly into your agent's system prompt. Agents (Claude, GPT, etc.) can apply domain-specific expertise on the fly, catching subtle violations that generic rules miss.</p>
+      </div>
+      <div class="embed-guide__section">
+        <h3>Use in a skill or plugin</h3>
+        <p>Build a skill that loads instructions programmatically — e.g., <code>/claude-code-review my-file.js</code> fetches the relevant instruction for that language and applies it. Skills compose instructions with the target code and invoke the agent.</p>
+      </div>
+      <div class="embed-guide__section">
+        <h3>Use in a code review harness</h3>
+        <p>Store instructions in a database or fetch from <code>/raw/</code> endpoints. Gate them by language, repository, or domain. A review harness finds the matching instructions and passes them as context to the review model.</p>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Replace the static counters display with an interactive embed guide that shows users three ways to use instructions: in AI agents, as skills/plugins, and in code review harnesses.

## Changes

- **Removed** `.counters` styles and markup that displayed total instructions, domains, repositories, and last update timestamp
- **Added** `.embed-guide` grid layout (auto-fit columns, 240px minimum) with three `.embed-guide__section` cards
- **Added** styling for embed guide sections: surface background, border, padding, and typography for headings and descriptions
- **Added** inline code styling within guide sections with distinct background and border treatment
- **Updated** HTML to replace counter divs with three guide sections explaining practical usage patterns

The new guide provides actionable context for how consumers can integrate instructions into their workflows, replacing passive metrics with active guidance.

https://claude.ai/code/session_014mkhR3euCfXyVF1wwWvy8h