### PR TITLE
Simplify UI by removing metadata counts and statistics

### DIFF
--- a/_layouts/domain.html
+++ b/_layouts/domain.html
@@ -11,13 +11,11 @@ layout: base
     <h1>{{ domain.title }}</h1>
     <p class="intro__lead">{{ domain.blurb }}</p>
     <div class="counters">
-      <div><b>{{ domain.count }}</b> instructions</div>
-      <div><b>{{ domain.repositories }}</b> repositories</div>
       <div><b><time data-date="{{ domain.updated }}">{{ domain.updated }}</time></b> last update</div>
     </div>
     <div class="row__actions" style="margin-top:18px">
       <a class="btn btn--primary" href="{{ '/raw/bundles/' | append: page.domain | append: '.md' | relative_url }}">
-        download all {{ domain.count }} as one file
+        download all instructions
       </a>
       <a class="btn" href="{{ '/api/' | relative_url }}">raw access</a>
     </div>
@@ -28,7 +26,7 @@ layout: base
   <div class="wrap" data-filters>
     <div class="controls">
       <input type="search" autocomplete="off" spellcheck="false"
-             placeholder="Filter {{ domain.count }} instructions…" data-filter-text
+             placeholder="Filter instructions…" data-filter-text
              aria-label="Filter instructions in this domain">
       <select data-filter-key="topic" aria-label="Filter by topic">
         <option value="">All topics</option>

--- a/_layouts/reviewer.html
+++ b/_layouts/reviewer.html
@@ -33,7 +33,7 @@ layout: base
 
         {% if meta.discussions > 0 %}
         <details class="threads" data-threads="{{ page.slug }}">
-          <summary>Source discussions <span data-threads-count></span></summary>
+          <summary>Source discussions</summary>
           <div data-threads-body></div>
         </details>
         {% endif %}
@@ -59,7 +59,7 @@ layout: base
           </li>
           <li>
             <span class="k">Derived from</span>
-            <span class="v">{{ meta.discussions }} review threads · {{ page.comments_count | default: 0 }} comments</span>
+            <span class="v">Review discussions</span>
           </li>
           {% if meta.reviewers %}
           <li>

--- a/index.html
+++ b/index.html
@@ -11,8 +11,7 @@ description: Expert engineering instructions for AI and infrastructure domains, 
   <div class="wrap">
     <h1>Expert instructions for AI and infrastructure engineering</h1>
     <p class="intro__lead">
-      {{ total }} instruction sets distilled from review discussions in
-      {{ site.data.sources.sources | size }} production repositories — agent frameworks, inference
+      A library of instruction sets distilled from review discussions in production repositories — agent frameworks, inference
       servers, orchestration, databases, cloud infrastructure and the tooling around them.
       Each one is plain markdown: <strong>copy it here, or fetch it as raw text</strong> and load it
       into an agent, harness or context broker.
@@ -48,18 +47,16 @@ description: Expert engineering instructions for AI and infrastructure domains, 
     <div data-search-fallback>
       <div class="section__head" style="margin-top:24px">
         <h2>Domains</h2>
-        <p>counts and dates are derived from the underlying review discussions</p>
+        <p>organized by engineering discipline</p>
       </div>
       <div class="grid">
         {% for domain in stats.domains %}
         <div class="card">
           <div class="card__top">
             <h3><a href="{{ '/domains/' | append: domain.slug | append: '/' | relative_url }}">{{ domain.title }}</a></h3>
-            <span class="card__count">{{ domain.count }}</span>
           </div>
           <p class="card__blurb">{{ domain.blurb }}</p>
           <div class="card__foot">
-            <span>{{ domain.repositories }} repos</span>
             <time data-date="{{ domain.updated }}">{{ domain.updated }}</time>
           </div>
         </div>
@@ -68,7 +65,7 @@ description: Expert engineering instructions for AI and infrastructure domains, 
 
       <div class="section__head" style="margin-top:36px">
         <h2>Recently updated</h2>
-        <p><a href="{{ '/domains/' | relative_url }}">browse all {{ total }}</a></p>
+        <p><a href="{{ '/domains/' | relative_url }}">browse all instructions</a></p>
       </div>
       <ul class="rows">
         {% for entry in site.data.entries limit: 25 %}


### PR DESCRIPTION
Remove instruction counts, repository counts, and discussion thread counts from the UI across all pages. This simplifies the interface and reduces emphasis on quantitative metrics in favor of focusing on the content itself.

**Changes:**

- **Homepage (`index.html`)**: Remove total instruction count and source repository count from the intro text; update "Domains" section subtitle to focus on organization rather than data derivation; remove count badges and repository counts from domain cards
- **Domain pages (`_layouts/domain.html`)**: Remove instruction count and repository count from the counters section; simplify download button text to remove count reference; update search placeholder to remove count reference
- **Instruction detail pages (`_layouts/reviewer.html`)**: Remove discussion thread count from the "Source discussions" summary; simplify the "Derived from" metadata to show only "Review discussions" without specific counts

The changes maintain all functional links and navigation while presenting a cleaner, less metrics-focused interface. All data remains available via the API and raw endpoints.

https://claude.ai/code/session_01U8SEi9Biyggj7oJLAKzLf2